### PR TITLE
Shared library for eclipse builds.

### DIFF
--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -242,7 +242,7 @@ def call(body) {
 		}
 		throw err
 	} finally {
-		emailNotification(MAIL_DEFAULT_RECIPIENT)
+		emailNotification(MAIL_DEFAULT_RECIPIENT, skipNotification)
 	}
 
 }

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -1,4 +1,4 @@
-final MAIL_DEFAULT_RECIPIENT = new String('c3RlcGhhbi5zZWlmZXJtYW5uQGtpdC5lZHU='.decodeBase64())
+MAIL_DEFAULT_RECIPIENT = new String('c3RlcGhhbi5zZWlmZXJtYW5uQGtpdC5lZHU='.decodeBase64())
 
 def call(body) {
 
@@ -196,11 +196,15 @@ def notifyFailure() {
 }
 
 def notify(token, verb) {
-	mail([
-		subject: "${token}: build of ${JOB_NAME} #${BUILD_NUMBER}",
+
+	emailext([
+		attachLog: true,
 		body: "The build of ${JOB_NAME} #${BUILD_NUMBER} ${verb}.\nPlease visit ${BUILD_URL} for details.",
+		recipientProviders: [[$class: 'RequesterRecipientProvider'], [$class:'CulpritsRecipientProvider']]
+		subject: "${token}: build of ${JOB_NAME} #${BUILD_NUMBER}",
 		to: MAIL_DEFAULT_RECIPIENT
 	])
+
 }
 
 def previouslyFailed() {

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -166,7 +166,7 @@ def call(body) {
 					}
 				} finally {
 					stage ('Cleanup') {
-						sh 'ls -A1 | xargs rm -rf'
+						sh 'ls -A1 | xargs -0 rm -rf'
 					}
 				}
 			}

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -166,8 +166,7 @@ def call(body) {
 					}
 				} finally {
 					stage ('Cleanup') {
-						sh 'rm -rf ./*'
-						sh 'rm -rf ./.*'
+						sh 'ls -A1 | xargs rm -rf'
 					}
 				}
 			}

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -200,9 +200,9 @@ def notify(token, verb) {
 	emailext([
 		attachLog: true,
 		body: "The build of ${JOB_NAME} #${BUILD_NUMBER} ${verb}.\nPlease visit ${BUILD_URL} for details.",
-		recipientProviders: [[$class: 'RequesterRecipientProvider'], [$class:'CulpritsRecipientProvider']]
 		subject: "${token}: build of ${JOB_NAME} #${BUILD_NUMBER}",
-		to: MAIL_DEFAULT_RECIPIENT
+		to: MAIL_DEFAULT_RECIPIENT,
+		recipientProviders: [[$class: 'RequesterRecipientProvider'], [$class:'CulpritsRecipientProvider']]
 	])
 
 }

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -1,3 +1,5 @@
+final MAIL_DEFAULT_RECIPIENT = new String('c3RlcGhhbi5zZWlmZXJtYW5uQGtpdC5lZHU='.decodeBase64())
+
 def call(body) {
 
 	// mandatory framework stuff
@@ -11,7 +13,6 @@ def call(body) {
 	final BUILD_LIMIT_TIME = 30
 	final BUILD_LIMIT_RAM = '4G'
 	final BUILD_LIMIT_HDD = '20G'
-	final MAIL_DEFAULT_RECIPIENT = new String('c3RlcGhhbi5zZWlmZXJtYW5uQGtpdC5lZHU='.decodeBase64())
 
 	// evaluation of git build information
 	boolean isMasterBranch = "$BRANCH_NAME" == 'master'

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -35,6 +35,8 @@ def call(body) {
 	if (doReleaseBuild) {
 		currentBuild.rawBuild.keepLog(true)
 	}
+	
+	echo sh(returnStdout: true, script: 'env')
 
 	try {
 	
@@ -51,6 +53,7 @@ def call(body) {
 			echo "${env.CHANGE_TARGET}"
 			echo "${env.GIT_BRANCH}"
 			echo "$BRANCH_NAME"
+			echo sh(returnStdout: true, script: 'env')
 
 			node('docker') {
 				def workspace

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -1,0 +1,117 @@
+def call(body) {
+
+	def config = [:]
+	body.resolveStrategy = Closure.DELEGATE_FIRST
+	body.delegate = config
+	body()
+
+	try {
+	
+		def relativeArtifactsDir = "${config.updateSiteLocation}"
+		
+		pipeline {
+		
+			parameters {
+				booleanParam (name: 'Release', defaultValue: false, description: 'Set true for Release')
+				string (defaultValue: '', description: 'set Version of Release', name: 'ReleaseVersion', trim: true)
+			}
+			
+			options {
+                timeout(time: 30, unit: 'MINUTES')
+			}
+
+			node('docker') {
+				def workspace
+				
+				def slaveHome = "${env.SLAVE_HOME}"
+				def slaveUid = "${env.SLAVE_USER_ID}"
+				
+				stage ('Prepare') {
+					deleteDir()
+					workspace = pwd()
+				}
+				
+				
+				stage ('Checkout') {
+					checkout scm
+					/*
+					sh """docker run --rm \
+					-u ${slaveUid} \
+					-v ${workspace}:/git alpine/git clone \
+					--depth 1 \
+					https://github.com/PalladioSimulator/Palladio-ThirdParty-YakinduStateCharts.git \
+					./"""
+					*/
+				}
+				
+				stage ('Build') {
+					def cacheVolumeMount = "-v ${slaveHome}/.m2:/.m2:ro"
+					def cacheCopyCommand = 'cp -r /.m2 /tmp'
+					//def cacheVolumeMount = "-v ${slaveHome}/.m2:/tmp/.m2"
+					//def cacheCopyCommand = 'echo "Writable m2 cache enabled"'
+					try {
+						configFileProvider(
+							[configFile(fileId: 'fba2768e-c997-4043-b10b-b5ca461aff54', variable: 'MAVEN_SETTINGS')]) {
+							 sh """docker run --rm \
+								-u ${slaveUid} \
+								-w /tmp/ws \
+								-v ${workspace}:/tmp/ws \
+								${cacheVolumeMount} \
+								-v /tmp/emptyDir:/root/.m2:ro \
+								-v $MAVEN_SETTINGS:/settings.xml:ro \
+								-e MAVEN_CONFIG=/tmp/.m2 \
+								-e MAVEN_OPTS=-Duser.home=/tmp \
+								-m 4G \
+								--storage-opt size=20G \
+								--network proxy \
+								maven:3-jdk-11 /bin/sh -c '${cacheCopyCommand} && mvn -s /settings.xml clean verify'"""
+						}
+					} finally {
+						
+					}
+				}
+				
+				stage ('Archive') {
+					archiveArtifacts "${relativeArtifactsDir}/**/*"
+				}
+				
+				stage ('Quality Metrics') {
+					
+					publishHTML([
+						allowMissing: false,
+						alwaysLinkToLastBuild: false,
+						keepAll: false,
+						reportDir: "${relativeArtifactsDir}/javadoc",
+						reportFiles: 'overview-summary.html',
+						reportName: 'JavaDoc',
+						reportTitles: ''
+					])
+					
+					recordIssues([
+						tool: checkStyle([
+							pattern: '**/target/checkstyle-result.xml'
+						])
+					])
+		
+					junit([
+						testResults: '**/surefire-reports/*.xml',
+						allowEmptyResults: true
+					])
+					
+					jacoco([
+						execPattern: '**/target/*.exec',
+						classPattern: '**/target/classes',
+						sourcePattern: '**/src,**/src-gen,**/xtend-gen',
+						inclusionPattern: '**/*.class',
+						exclusionPattern: '**/*Test*.class'
+					])
+				}
+			} // node
+		}
+	} // try end
+	catch (err) {
+		currentBuild.result = "FAILURE"
+		throw err
+	}
+
+}

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -28,8 +28,8 @@ def call(body) {
 				final BUILD_IMAGE = 'maven:3-jdk-11'
 
 				// evaluation of git build information
-				boolean isPullRequest = env.CHANGE_TARGET.toBoolean()
-				boolean isMasterBranch = env.GIT_BRANCH == 'master'
+				boolean isPullRequest = ${env.CHANGE_TARGET}.toBoolean()
+				boolean isMasterBranch = ${env.GIT_BRANCH} == 'master'
 
 				// evaluation of build parameters
 				String relativeArtifactsDir = "${config.updateSiteLocation}"

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -166,7 +166,7 @@ def call(body) {
 					}
 				} finally {
 					stage ('Cleanup') {
-						sh 'rm -rf ./*'
+						sh 'rm -f "./{*,.*}"'
 					}
 				}
 			}

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -51,7 +51,6 @@ def call(body) {
 			echo "${env.CHANGE_TARGET}"
 			echo "${env.GIT_BRANCH}"
 			echo "$BRANCH_NAME"
-			echo sh(returnStdout: true, script: 'env')
 
 			node('docker') {
 				def workspace

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -28,8 +28,8 @@ def call(body) {
 				final BUILD_IMAGE = 'maven:3-jdk-11'
 
 				// evaluation of git build information
-				boolean isPullRequest = ${env.CHANGE_TARGET}.toBoolean()
-				boolean isMasterBranch = ${env.GIT_BRANCH} == 'master'
+				boolean isPullRequest = "${env.CHANGE_TARGET}".toBoolean()
+				boolean isMasterBranch = "${env.GIT_BRANCH}" == 'master'
 
 				// evaluation of build parameters
 				String relativeArtifactsDir = "${config.updateSiteLocation}"

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -12,9 +12,9 @@ def call(body) {
 
 	// evaluation of git build information
 	boolean isMasterBranch = "$BRANCH_NAME" == 'master'
-	echo "Is master branch: $isMasterBranch.toString()"
+	echo "Is master branch: $isMasterBranch"
 	boolean isPullRequest = !"${env.CHANGE_TARGET}".trim().isEmpty()
-	echo "Is pull request: $isPullRequest.toString()"
+	echo "Is pull request: $isPullRequest"
 
 	// evaluation of build parameters
 	String relativeArtifactsDir = "${config.updateSiteLocation}"

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -193,20 +193,33 @@ def call(body) {
 													sshTransfer(
 														sourceFiles: "$COMPOSITE_SCRIPT",
 														removePrefix: "${compositeScript.getParent()}",
-														remoteDirectory: "${config.webserverDir}",
-														execCommand:
-															"cd $WEB_ROOT/${config.webserverDir} && " +
-															"mkdir -p releases/$releaseVersion && " +
-															"cp -a nightly/* releases/$releaseVersion/ && " +
-															"chmod +x $compositeScriptName && " +
-															"$compositeScriptName releases && " +
-															"rm $compositeScriptName"
+														remoteDirectory: "${config.webserverDir}"
 													)
 												]
 											)
 										]
 									)
 								}
+								sshPublisher(
+									failOnError: true,
+									publishers: [
+										sshPublisherDesc(
+											configName: SSH_NAME,
+											transfers: [
+												sshTransfer(
+													execCommand:
+														"cd $WEB_ROOT/${config.webserverDir} && " +
+														"mkdir -p releases/$releaseVersion && " +
+														"cp -a nightly/* releases/$releaseVersion/ && " +
+														"chmod +x $compositeScriptName && " +
+														"$compositeScriptName releases && " +
+														"rm $compositeScriptName"
+												)
+											]
+										)
+									]
+								)
+								
 							}
 					
 						}

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -50,6 +50,7 @@ def call(body) {
 			
 			echo "${env.CHANGE_TARGET}"
 			echo "${env.GIT_BRANCH}"
+			echo "$BRANCH_NAME"
 
 			node('docker') {
 				def workspace

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -13,7 +13,7 @@ def call(body) {
 	// evaluation of git build information
 	boolean isMasterBranch = "$BRANCH_NAME" == 'master'
 	echo "Is master branch: $isMasterBranch"
-	boolean isPullRequest = env.CHANGE_TARGET
+	boolean isPullRequest = !(env.CHANGE_TARGET == null)
 	echo "Is pull request: $isPullRequest"
 
 	// evaluation of build parameters

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -166,7 +166,8 @@ def call(body) {
 					}
 				} finally {
 					stage ('Cleanup') {
-						sh 'rm -rf "./{*,.*}"'
+						sh 'rm -rf ./*'
+						sh 'rm -rf ./.*'
 					}
 				}
 			}

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -63,6 +63,7 @@ def call(body) {
 				stage ('Prepare') {
 					deleteDir()
 					workspace = pwd()
+					sh "mkdir -p $slaveHome/.m2"
 				}
 				
 				stage ('Checkout') {

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -196,13 +196,17 @@ def notifyFailure(defaultRecipient) {
 
 def notify(defaultRecipient, token, verb) {
 
-	emailext([
-		attachLog: true,
-		body: "The build of ${JOB_NAME} #${BUILD_NUMBER} ${verb}.\nPlease visit ${BUILD_URL} for details.",
-		subject: "${token}: build of ${JOB_NAME} #${BUILD_NUMBER}",
-		to: defaultRecipient,
-		recipientProviders: [[$class: 'RequesterRecipientProvider'], [$class:'CulpritsRecipientProvider']]
-	])
+    wrap([$class: 'MaskPasswordsBuildWrapper', varMaskRegexes: [
+		[regex: '[^\s]+@[^\s,]+']
+	]]) {
+		emailext([
+			attachLog: true,
+			body: "The build of ${JOB_NAME} #${BUILD_NUMBER} ${verb}.\nPlease visit ${BUILD_URL} for details.",
+			subject: "${token}: build of ${JOB_NAME} #${BUILD_NUMBER}",
+			to: defaultRecipient,
+			recipientProviders: [[$class: 'RequesterRecipientProvider'], [$class:'CulpritsRecipientProvider']]
+		])
+    }
 
 }
 

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -84,8 +84,8 @@ def call(body) {
 								--storage-opt size=20G \
 								--network proxy \
 							""") { c ->
-								sh "docker exec ${c.id} cp /.m2 /tmp"
-								sh "docker exec ${c.id} cp /ws /tmp"
+								sh "docker exec ${c.id} cp -r /.m2 /tmp"
+								sh "docker exec ${c.id} cp -r /ws /tmp"
 								sh "docker exec ${c.id} mvn -s /settings.xml -f /tmp/ws/pom.xml clean verify"
 								sh "docker cp ${c.id}/tmp/ws ${workspace}"
 								if (isMasterBranch && !isPullRequest) {

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -18,39 +18,40 @@ def call(body) {
 				])
 			])
 
-			// build constants
-			final BUILD_IMAGE = 'maven:3-jdk-11'
-
-			// evaluation of git build information
-			boolean isPullRequest = env.CHANGE_TARGET.toBoolean()
-			boolean isMasterBranch = env.GIT_BRANCH == 'master'
-
-			// evaluation of build parameters
-			String relativeArtifactsDir = "${config.updateSiteLocation}"
-			final MANDATORY_PARAMS = ['gitUrl', 'webserverDir', 'updateSiteLocation']
-			for (mandatoryParameter in MANDATORY_PARAMS) {
-				if (!config.containsKey(mandatoryParameter) || config.get(mandatoryParameter).toString().trim().isEmpty()) {
-					error "Missing mandatory parameter $mandatoryParameter"
-				}
-			}
-			boolean skipCodeQuality = config.containsKey('skipCodeQuality') && config.get('skipCodeQuality').toString().trim().toBoolean()
-			boolean skipNotification = config.containsKey('skipNotification') && config.get('skipNotification').toString().trim().toBoolean()
-			boolean doReleaseBuild = params.DO_RELEASE_BUILD.toString().toBoolean()
-			String releaseVersion = params.RELEASE_VERSION
-			if (doReleaseBuild && (releaseVersion == null || releaseVersion.trim().isEmpty())) {
-				error 'A release build requires a proper release version.'
-			}
-
-			// archive release build
-			if (doReleaseBuild) {
-				currentBuild.rawBuild.keepLog(true)
-			}
-
 			node('docker') {
 				def workspace
 				
 				def slaveHome = "${env.SLAVE_HOME}"
 				def slaveUid = "${env.SLAVE_USER_ID}"
+				
+				// build constants
+				final BUILD_IMAGE = 'maven:3-jdk-11'
+
+				// evaluation of git build information
+				boolean isPullRequest = env.CHANGE_TARGET.toBoolean()
+				boolean isMasterBranch = env.GIT_BRANCH == 'master'
+
+				// evaluation of build parameters
+				String relativeArtifactsDir = "${config.updateSiteLocation}"
+				final MANDATORY_PARAMS = ['gitUrl', 'webserverDir', 'updateSiteLocation']
+				for (mandatoryParameter in MANDATORY_PARAMS) {
+					if (!config.containsKey(mandatoryParameter) || config.get(mandatoryParameter).toString().trim().isEmpty()) {
+						error "Missing mandatory parameter $mandatoryParameter"
+					}
+				}
+				boolean skipCodeQuality = config.containsKey('skipCodeQuality') && config.get('skipCodeQuality').toString().trim().toBoolean()
+				boolean skipNotification = config.containsKey('skipNotification') && config.get('skipNotification').toString().trim().toBoolean()
+				boolean doReleaseBuild = params.DO_RELEASE_BUILD.toString().toBoolean()
+				String releaseVersion = params.RELEASE_VERSION
+				if (doReleaseBuild && (releaseVersion == null || releaseVersion.trim().isEmpty())) {
+					error 'A release build requires a proper release version.'
+				}
+
+				// archive release build
+				if (doReleaseBuild) {
+					currentBuild.rawBuild.keepLog(true)
+				}
+
 				
 				stage ('Prepare') {
 					deleteDir()

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -164,6 +164,7 @@ def call(body) {
 						//if (!isPullRequest && isMasterBranch) {
 						
 							sshPublisher(
+								alwaysPublishFromMaster: true,
 								failOnError: true,
 								publishers: [
 									sshPublisherDesc(
@@ -187,23 +188,18 @@ def call(body) {
 									sh "cp $COMPOSITE_SCRIPT ./$SCRIPTNAME"
 									try {
 										sshPublisher(
+											alwaysPublishFromMaster: true,
 											failOnError: true,
 											publishers: [
 												sshPublisherDesc(
 													configName: SSH_NAME,
-													verbose: true,
 													transfers: [
 														sshTransfer(
 															sourceFiles: "$SCRIPTNAME",
 															remoteDirectory: "${config.webserverDir}"
 														)
 													]
-												)
-											]
-										)
-										sshPublisher(
-											failOnError: true,
-											publishers: [
+												),
 												sshPublisherDesc(
 													configName: SSH_NAME,
 													transfers: [

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -189,9 +189,10 @@ def call(body) {
 										publishers: [
 											sshPublisherDesc(
 												configName: SSH_NAME,
+												verbose: true,
 												transfers: [
 													sshTransfer(
-														sourceFiles: "$COMPOSITE_SCRIPT",
+														sourceFiles: "${COMPOSITE_SCRIPT}",
 														removePrefix: "${compositeScript.getParent()}",
 														remoteDirectory: "${config.webserverDir}"
 													)

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -84,6 +84,8 @@ def call(body) {
 								-m 4G \
 								--storage-opt size=20G \
 								--network proxy \
+								-it \
+								--entrypoint=/bin/cat
 							""") { c ->
 								sh "docker exec ${c.id} cp -r /.m2 /tmp"
 								sh "docker exec ${c.id} cp -r /ws /tmp"

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -85,7 +85,7 @@ def call(body) {
 								--storage-opt size=20G \
 								--network proxy \
 								-it \
-								--entrypoint=/bin/cat
+								--entrypoint=/bin/cat \
 							""") { c ->
 								sh "docker exec ${c.id} cp -r /.m2 /tmp"
 								sh "docker exec ${c.id} cp -r /ws /tmp"

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -11,7 +11,7 @@ def call(body) {
 	final BUILD_LIMIT_TIME = 30
 	final BUILD_LIMIT_RAM = '4G'
 	final BUILD_LIMIT_HDD = '20G'
-	final MAIL_DEFAULT_RECIPIENT = new String('c3RlcGhhbi5zZWlmZXJtYW5uQGtpdC5lZHU='.decodeBase64()
+	final MAIL_DEFAULT_RECIPIENT = new String('c3RlcGhhbi5zZWlmZXJtYW5uQGtpdC5lZHU='.decodeBase64())
 
 	// evaluation of git build information
 	boolean isMasterBranch = "$BRANCH_NAME" == 'master'

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -198,7 +198,7 @@ def notify(token, verb) {
 	mail([
 		subject: "${token}: build of ${JOB_NAME} #${BUILD_NUMBER}",
 		body: "The build of ${JOB_NAME} #${BUILD_NUMBER} ${verb}.\nPlease visit ${BUILD_URL} for details.",
-		to: MAIL_DEFAULT_RECIPIENT)
+		to: MAIL_DEFAULT_RECIPIENT
 	])
 }
 

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -102,7 +102,7 @@ def call(body) {
 										sh "docker exec ${c.id} cp -r /ws /tmp"
 										sh "docker exec ${c.id} mvn -s /settings.xml -f /tmp/ws/pom.xml clean verify"
 										sh "docker cp ${c.id}:/tmp/ws/. ${workspace}"
-										if (isMasterBranch && !isPullRequest) {
+										if (!isPullRequest) {
 											sh "docker cp ${c.id}:/tmp/.m2/. ${slaveHome}/.m2"
 										}
 									}

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -1,5 +1,3 @@
-MAIL_DEFAULT_RECIPIENT = new String('c3RlcGhhbi5zZWlmZXJtYW5uQGtpdC5lZHU='.decodeBase64())
-
 def call(body) {
 
 	// mandatory framework stuff
@@ -9,6 +7,7 @@ def call(body) {
 	body()
 	
 	// build constants
+	final MAIL_DEFAULT_RECIPIENT = new String('c3RlcGhhbi5zZWlmZXJtYW5uQGtpdC5lZHU='.decodeBase64())
 	final BUILD_IMAGE = 'maven:3-jdk-11'
 	final BUILD_LIMIT_TIME = 30
 	final BUILD_LIMIT_RAM = '4G'
@@ -178,30 +177,30 @@ def call(body) {
 
 		if (!skipNotification) {
 			if (currentResult == 'FAILURE') {
-				notifyFailure()
+				notifyFailure(MAIL_DEFAULT_RECIPIENT)
 			} else if (currentResult == 'SUCCESS' && previouslyFailed()) {
-				notifyFix()
+				notifyFix(MAIL_DEFAULT_RECIPIENT)
 			}
 		}
 	}
 
 }
 
-def notifyFix() {
-	notify('FIXED', 'fixed previous build errors')
+def notifyFix(defaultRecipient) {
+	notify(defaultRecipient, 'FIXED', 'fixed previous build errors')
 }
 
-def notifyFailure() {
-	notify('FAILED', 'failed')
+def notifyFailure(defaultRecipient) {
+	notify(defaultRecipient, 'FAILED', 'failed')
 }
 
-def notify(token, verb) {
+def notify(defaultRecipient, token, verb) {
 
 	emailext([
 		attachLog: true,
 		body: "The build of ${JOB_NAME} #${BUILD_NUMBER} ${verb}.\nPlease visit ${BUILD_URL} for details.",
 		subject: "${token}: build of ${JOB_NAME} #${BUILD_NUMBER}",
-		to: MAIL_DEFAULT_RECIPIENT,
+		to: defaultRecipient,
 		recipientProviders: [[$class: 'RequesterRecipientProvider'], [$class:'CulpritsRecipientProvider']]
 	])
 

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -90,9 +90,9 @@ def call(body) {
 								sh "docker exec ${c.id} cp -r /.m2 /tmp"
 								sh "docker exec ${c.id} cp -r /ws /tmp"
 								sh "docker exec ${c.id} mvn -s /settings.xml -f /tmp/ws/pom.xml clean verify"
-								sh "docker cp ${c.id}:/tmp/ws ${workspace}"
+								sh "docker cp ${c.id}:/tmp/ws/. ${workspace}"
 								if (isMasterBranch && !isPullRequest) {
-									sh "docker cp ${c.id}:/tmp/.m2 ${slaveHome}/.m2"
+									sh "docker cp ${c.id}:/tmp/.m2/. ${slaveHome}/.m2"
 								}
 							}
 

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -197,7 +197,7 @@ def notifyFailure(defaultRecipient) {
 def notify(defaultRecipient, token, verb) {
 
     wrap([$class: 'MaskPasswordsBuildWrapper', varMaskRegexes: [
-		[regex: '[^\s]+@[^\s,]+']
+		[regex: '[^\\s]+@[^\\s,]+']
 	]]) {
 		emailext([
 			attachLog: true,

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -90,9 +90,9 @@ def call(body) {
 								sh "docker exec ${c.id} cp -r /.m2 /tmp"
 								sh "docker exec ${c.id} cp -r /ws /tmp"
 								sh "docker exec ${c.id} mvn -s /settings.xml -f /tmp/ws/pom.xml clean verify"
-								sh "docker cp ${c.id}/tmp/ws ${workspace}"
+								sh "docker cp ${c.id}:/tmp/ws ${workspace}"
 								if (isMasterBranch && !isPullRequest) {
-									sh "docker cp ${c.id}/tmp/.m2 ${slaveHome}/.m2"
+									sh "docker cp ${c.id}:/tmp/.m2 ${slaveHome}/.m2"
 								}
 							}
 

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -30,8 +30,8 @@ def call(body) {
 	}
 	boolean skipCodeQuality = config.containsKey('skipCodeQuality') && config.get('skipCodeQuality').toString().trim().toBoolean()
 	boolean skipNotification = config.containsKey('skipNotification') && config.get('skipNotification').toString().trim().toBoolean()
-	boolean doReleaseBuild = params.DO_RELEASE_BUILD.toString().toBoolean()
-	String releaseVersion = params.RELEASE_VERSION
+	boolean doReleaseBuild = params.Release.toString().toBoolean()
+	String releaseVersion = params.ReleaseVersion
 	if (doReleaseBuild && (releaseVersion == null || releaseVersion.trim().isEmpty())) {
 		error 'A release build requires a proper release version.'
 	}

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -35,8 +35,6 @@ def call(body) {
 	if (doReleaseBuild) {
 		currentBuild.rawBuild.keepLog(true)
 	}
-	
-	echo sh(returnStdout: true, script: 'env')
 
 	try {
 	

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -6,34 +6,6 @@ def call(body) {
 	body.delegate = config
 	body()
 
-	// build constants
-	final BUILD_IMAGE = 'maven:3-jdk-11'
-
-	// evaluation of git build information
-	boolean isPullRequest = env.CHANGE_TARGET.toBoolean()
-	boolean isMasterBranch = env.GIT_BRANCH == 'master'
-
-	// evaluation of build parameters
-	String relativeArtifactsDir = "${config.updateSiteLocation}"
-	final MANDATORY_PARAMS = ['gitUrl', 'webserverDir', 'updateSiteLocation']
-	for (mandatoryParameter in MANDATORY_PARAMS) {
-		if (!config.containsKey(mandatoryParameter) || config.get(mandatoryParameter).toString().trim().isEmpty()) {
-			error "Missing mandatory parameter $mandatoryParameter"
-		}
-	}
-	boolean skipCodeQuality = config.containsKey('skipCodeQuality') && config.get('skipCodeQuality').toString().trim().toBoolean()
-	boolean skipNotification = config.containsKey('skipNotification') && config.get('skipNotification').toString().trim().toBoolean()
-	boolean doReleaseBuild = params.DO_RELEASE_BUILD.toString().toBoolean()
-	String releaseVersion = params.RELEASE_VERSION
-	if (doReleaseBuild && (releaseVersion == null || releaseVersion.trim().isEmpty())) {
-		error 'A release build requires a proper release version.'
-	}
-
-	// archive release build
-	if (doReleaseBuild) {
-		currentBuild.rawBuild.keepLog(true)
-	}
-
 	try {
 	
 		pipeline {
@@ -44,7 +16,35 @@ def call(body) {
 					booleanParam(defaultValue: false, name: 'Release', description: 'Set true for release build'),
 					string(defaultValue: 'nightly', name: 'ReleaseVersion', description: 'Set version to be used for the release')
 				])
-			])    
+			])
+
+			// build constants
+			final BUILD_IMAGE = 'maven:3-jdk-11'
+
+			// evaluation of git build information
+			boolean isPullRequest = env.CHANGE_TARGET.toBoolean()
+			boolean isMasterBranch = env.GIT_BRANCH == 'master'
+
+			// evaluation of build parameters
+			String relativeArtifactsDir = "${config.updateSiteLocation}"
+			final MANDATORY_PARAMS = ['gitUrl', 'webserverDir', 'updateSiteLocation']
+			for (mandatoryParameter in MANDATORY_PARAMS) {
+				if (!config.containsKey(mandatoryParameter) || config.get(mandatoryParameter).toString().trim().isEmpty()) {
+					error "Missing mandatory parameter $mandatoryParameter"
+				}
+			}
+			boolean skipCodeQuality = config.containsKey('skipCodeQuality') && config.get('skipCodeQuality').toString().trim().toBoolean()
+			boolean skipNotification = config.containsKey('skipNotification') && config.get('skipNotification').toString().trim().toBoolean()
+			boolean doReleaseBuild = params.DO_RELEASE_BUILD.toString().toBoolean()
+			String releaseVersion = params.RELEASE_VERSION
+			if (doReleaseBuild && (releaseVersion == null || releaseVersion.trim().isEmpty())) {
+				error 'A release build requires a proper release version.'
+			}
+
+			// archive release build
+			if (doReleaseBuild) {
+				currentBuild.rawBuild.keepLog(true)
+			}
 
 			node('docker') {
 				def workspace

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -13,6 +13,7 @@ def call(body) {
 	final BUILD_LIMIT_RAM = '4G'
 	final BUILD_LIMIT_HDD = '20G'
 	final SSH_NAME = 'web'
+	final WEB_ROOT = '/home/deploy/html'
 
 	// evaluation of git build information
 	boolean isMasterBranch = "$BRANCH_NAME" == 'master'
@@ -194,11 +195,12 @@ def call(body) {
 														removePrefix: "${compositeScript.getParent()}",
 														remoteDirectory: "${config.webserverDir}",
 														execCommand:
-															"mkdir -p ${config.webserverDir}/releases/$releaseVersion && " +
-															"cp -a ${config.webserverDir}/nightly/* ${config.webserverDir}/releases/$releaseVersion/ && " +
-															"chmod +x ${config.webserverDir}/$compositeScriptName && " +
-															"${config.webserverDir}/$compositeScriptName ${config.webserverDir}/releases && " +
-															"rm ${config.webserverDir}/$compositeScriptName"
+															"cd $WEB_ROOT/${config.webserverDir} && " +
+															"mkdir -p releases/$releaseVersion && " +
+															"cp -a nightly/* releases/$releaseVersion/ && " +
+															"chmod +x $compositeScriptName && " +
+															"$compositeScriptName releases && " +
+															"rm $compositeScriptName"
 													)
 												]
 											)

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -74,6 +74,7 @@ def call(body) {
 							
 							// run maven build in docker container
 							docker.image(BUILD_IMAGE).withRun("""\
+								-u ${slaveUid} \
 								-v ${workspace}:/ws:ro \
 								-v ${slaveHome}/.m2:/.m2:ro \
 								-v /tmp/emptyDir:/root/.m2:ro \

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -195,18 +195,19 @@ def notifyFailure(defaultRecipient) {
 }
 
 def notify(defaultRecipient, token, verb) {
-
-    wrap([$class: 'MaskPasswordsBuildWrapper', varMaskRegexes: [
-		[regex: '[^\\s]+@[^\\s,]+']
-	]]) {
-		emailext([
-			attachLog: true,
-			body: "The build of ${JOB_NAME} #${BUILD_NUMBER} ${verb}.\nPlease visit ${BUILD_URL} for details.",
-			subject: "${token}: build of ${JOB_NAME} #${BUILD_NUMBER}",
-			to: defaultRecipient,
-			recipientProviders: [[$class: 'RequesterRecipientProvider'], [$class:'CulpritsRecipientProvider']]
-		])
-    }
+	node {
+		wrap([$class: 'MaskPasswordsBuildWrapper', varMaskRegexes: [
+			[regex: '[^\\s]+@[^\\s,]+']
+		]]) {
+			emailext([
+				attachLog: true,
+				body: "The build of ${JOB_NAME} #${BUILD_NUMBER} ${verb}.\nPlease visit ${BUILD_URL} for details.",
+				subject: "${token}: build of ${JOB_NAME} #${BUILD_NUMBER}",
+				to: defaultRecipient,
+				recipientProviders: [[$class: 'RequesterRecipientProvider'], [$class:'CulpritsRecipientProvider']]
+			])
+		}
+	}
 
 }
 

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -69,7 +69,7 @@ def call(body) {
 				}
 				
 				stage ('Build') {
-					timeout(time: $BUILD_TIMEOUT, unit: 'MINUTES') {
+					timeout(time: BUILD_TIMEOUT, unit: 'MINUTES') {
 
 						// treat maven cache read only by default
 						def cacheVolumeMount = "-v ${slaveHome}/.m2:/.m2:ro"

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -184,6 +184,10 @@ def call(body) {
 									[configFile(fileId: '57dc902b-f5a7-49a9-aec3-98deabe48580', variable: 'COMPOSITE_SCRIPT')]) {
 									def compositeScript = new File("$COMPOSITE_SCRIPT")
 									def compositeScriptName = compositeScript.getName()
+									
+									echo "${COMPOSITE_SCRIPT}"
+									echo "${compositeScript.getParent()}"
+									
 									sshPublisher(
 										failOnError: true,
 										publishers: [
@@ -212,7 +216,7 @@ def call(body) {
 															"mkdir -p releases/$releaseVersion && " +
 															"cp -a nightly/* releases/$releaseVersion/ && " +
 															"chmod +x $compositeScriptName && " +
-															"$compositeScriptName releases && " +
+															"./$compositeScriptName releases && " +
 															"rm $compositeScriptName"
 													)
 												]

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -47,6 +47,9 @@ def call(body) {
 					string(defaultValue: 'nightly', name: 'ReleaseVersion', description: 'Set version to be used for the release')
 				])
 			])
+			
+			echo "${env.CHANGE_TARGET}"
+			echo "${env.GIT_BRANCH}"
 
 			node('docker') {
 				def workspace
@@ -61,6 +64,8 @@ def call(body) {
 				
 				stage ('Checkout') {
 					checkout scm
+					echo "${env.CHANGE_TARGET}"
+					echo "${env.GIT_BRANCH}"
 				}
 				
 				stage ('Build') {

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -201,7 +201,7 @@ def call(body) {
 					}
 				} finally {
 					stage ('Cleanup') {
-						sh 'ls -A1 | xargs -0 rm -rf'
+						sh 'ls -A1 | xargs -d '\n' rm -rf'
 					}
 				}
 			}

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -192,7 +192,7 @@ def call(body) {
 													sshTransfer(
 														sourceFiles: "$COMPOSITE_SCRIPT",
 														removePrefix: "${compositeScript.getParent()}",
-														remoteDirectory: "${config.webserverDir}"
+														remoteDirectory: "${config.webserverDir}",
 														execCommand:
 															"mkdir -p ${config.webserverDir}/releases/$releaseVersion && " +
 															"cp -a ${config.webserverDir}/nightly/* ${config.webserverDir}/releases/$releaseVersion/ && " +

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -67,6 +67,7 @@ def call(body) {
 					checkout scm
 					echo "${env.CHANGE_TARGET}"
 					echo "${env.GIT_BRANCH}"
+					echo sh(returnStdout: true, script: 'env')
 				}
 				
 				stage ('Build') {

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -33,7 +33,7 @@ def call(body) {
 
 				// evaluation of build parameters
 				String relativeArtifactsDir = "${config.updateSiteLocation}"
-				final MANDATORY_PARAMS = ['gitUrl', 'webserverDir', 'updateSiteLocation']
+				final MANDATORY_PARAMS = ['webserverDir', 'updateSiteLocation']
 				for (mandatoryParameter in MANDATORY_PARAMS) {
 					if (!config.containsKey(mandatoryParameter) || config.get(mandatoryParameter).toString().trim().isEmpty()) {
 						error "Missing mandatory parameter $mandatoryParameter"

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -196,7 +196,7 @@ def call(body) {
 												verbose: true,
 												transfers: [
 													sshTransfer(
-														sourceFiles: "${COMPOSITE_SCRIPT}",
+														sourceFiles: "${compositeScript.getParent()}/*",
 														removePrefix: "${compositeScript.getParent()}",
 														remoteDirectory: "${config.webserverDir}"
 													)

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -199,27 +199,26 @@ def call(body) {
 											)
 										]
 									)
+									sshPublisher(
+										failOnError: true,
+										publishers: [
+											sshPublisherDesc(
+												configName: SSH_NAME,
+												transfers: [
+													sshTransfer(
+														execCommand:
+															"cd $WEB_ROOT/${config.webserverDir} && " +
+															"mkdir -p releases/$releaseVersion && " +
+															"cp -a nightly/* releases/$releaseVersion/ && " +
+															"chmod +x $compositeScriptName && " +
+															"$compositeScriptName releases && " +
+															"rm $compositeScriptName"
+													)
+												]
+											)
+										]
+									)
 								}
-								sshPublisher(
-									failOnError: true,
-									publishers: [
-										sshPublisherDesc(
-											configName: SSH_NAME,
-											transfers: [
-												sshTransfer(
-													execCommand:
-														"cd $WEB_ROOT/${config.webserverDir} && " +
-														"mkdir -p releases/$releaseVersion && " +
-														"cp -a nightly/* releases/$releaseVersion/ && " +
-														"chmod +x $compositeScriptName && " +
-														"$compositeScriptName releases && " +
-														"rm $compositeScriptName"
-												)
-											]
-										)
-									]
-								)
-								
 							}
 					
 						}

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -70,8 +70,8 @@ def call(body) {
 
 						// treat maven cache writable for master branch
 						if (isMasterBranch && !isPullRequest) {
-							def cacheVolumeMount = "-v ${slaveHome}/.m2:/tmp/.m2"
-							def cacheCopyCommand = 'echo "Writable m2 cache enabled"'
+							cacheVolumeMount = "-v ${slaveHome}/.m2:/tmp/.m2"
+							cacheCopyCommand = 'echo "Writable m2 cache enabled"'
 						}
 
 						// inject maven config file

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -242,55 +242,7 @@ def call(body) {
 		}
 		throw err
 	} finally {
-		def currentResult = currentBuild.result ?: 'SUCCESS'
-		def previousResult = currentBuild.previousBuild?.result ?: 'SUCCESS'
-
-		if (!skipNotification) {
-			if (currentResult == 'FAILURE') {
-				notifyFailure(MAIL_DEFAULT_RECIPIENT)
-			} else if (currentResult == 'SUCCESS' && previouslyFailed()) {
-				notifyFix(MAIL_DEFAULT_RECIPIENT)
-			}
-		}
+		emailNotification(MAIL_DEFAULT_RECIPIENT)
 	}
 
-}
-
-def notifyFix(defaultRecipient) {
-	notify(defaultRecipient, 'FIXED', 'fixed previous build errors')
-}
-
-def notifyFailure(defaultRecipient) {
-	notify(defaultRecipient, 'FAILED', 'failed')
-}
-
-def notify(defaultRecipient, token, verb) {
-	node {
-		wrap([$class: 'MaskPasswordsBuildWrapper', varMaskRegexes: [
-			[regex: '@[^\\s,]+']
-		]]) {
-			emailext([
-				attachLog: true,
-				body: "The build of ${JOB_NAME} #${BUILD_NUMBER} ${verb}.\nPlease visit ${BUILD_URL} for details.",
-				subject: "${token}: build of ${JOB_NAME} #${BUILD_NUMBER}",
-				to: defaultRecipient,
-				recipientProviders: [[$class: 'RequesterRecipientProvider'], [$class:'CulpritsRecipientProvider']]
-			])
-		}
-	}
-
-}
-
-def previouslyFailed() {
-	for (buildObject = currentBuild.previousBuild; buildObject != null; buildObject = buildObject.previousBuild) {
-		if (buildObject.result == null) {
-			continue
-		}
-		if (buildObject.result == 'FAILURE') {
-			return true
-		}
-		if (buildObject.resultIsBetterOrEqualTo('UNSTABLE')) {
-			return false
-		}
-	}
 }

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -8,7 +8,9 @@ def call(body) {
 	
 	// build constants
 	final BUILD_IMAGE = 'maven:3-jdk-11'
-	final BUILD_TIMEOUT = 30
+	final BUILD_LIMIT_TIME = 30
+	final BUILD_LIMIT_RAM = '4G'
+	final BUILD_LIMIT_HDD = '20G'
 
 	// evaluation of git build information
 	boolean isMasterBranch = "$BRANCH_NAME" == 'master'
@@ -66,7 +68,7 @@ def call(body) {
 				}
 				
 				stage ('Build') {
-					timeout(time: BUILD_TIMEOUT, unit: 'MINUTES') {
+					timeout(time: BUILD_LIMIT_TIME, unit: 'MINUTES') {
 
 						// inject maven config file
 						configFileProvider(
@@ -81,8 +83,8 @@ def call(body) {
 								-v $MAVEN_SETTINGS:/settings.xml:ro \
 								-e MAVEN_CONFIG=/tmp/.m2 \
 								-e MAVEN_OPTS=-Duser.home=/tmp \
-								-m 4G \
-								--storage-opt size=20G \
+								-m $BUILD_LIMIT_RAM \
+								--storage-opt size=$BUILD_LIMIT_HDD \
 								--network proxy \
 								-it \
 								--entrypoint=/bin/cat \

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -143,6 +143,7 @@ def call(body) {
 	}
 	catch (err) {
 		currentBuild.result = "FAILURE"
+		echo err
 		throw err
 	}
 

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -166,7 +166,7 @@ def call(body) {
 					}
 				} finally {
 					stage ('Cleanup') {
-						sh 'rm -f "./{*,.*}"'
+						sh 'rm -rf "./{*,.*}"'
 					}
 				}
 			}

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -14,6 +14,9 @@ def call(body) {
 	boolean isMasterBranch = "$BRANCH_NAME" == 'master'
 	echo "Is master branch: $isMasterBranch"
 	boolean isPullRequest = !"${env.CHANGE_TARGET}".trim().isEmpty()
+	echo "${env.CHANGE_TARGET}"
+	echo "${env.CHANGE_TARGET}".trim()
+	echo "${env.CHANGE_TARGET}".trim().isEmpty()
 	echo "Is pull request: $isPullRequest"
 
 	// evaluation of build parameters

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -10,8 +10,8 @@ def call(body) {
 	final BUILD_IMAGE = 'maven:3-jdk-11'
 
 	// evaluation of git build information
-	boolean isPullRequest = ${env.CHANGE_TARGET}.toBoolean()
-	boolean isMasterBranch = ${env.GIT_BRANCH} == 'master'
+	boolean isPullRequest = env.CHANGE_TARGET.toBoolean()
+	boolean isMasterBranch = env.GIT_BRANCH == 'master'
 
 	// evaluation of build parameters
 	String relativeArtifactsDir = "${config.updateSiteLocation}"

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -201,7 +201,7 @@ def call(body) {
 					}
 				} finally {
 					stage ('Cleanup') {
-						sh 'ls -A1 | xargs -d '\n' rm -rf'
+						sh "ls -A1 | xargs -d '\n' rm -rf"
 					}
 				}
 			}

--- a/vars/buildPipeline.groovy
+++ b/vars/buildPipeline.groovy
@@ -13,10 +13,7 @@ def call(body) {
 	// evaluation of git build information
 	boolean isMasterBranch = "$BRANCH_NAME" == 'master'
 	echo "Is master branch: $isMasterBranch"
-	boolean isPullRequest = !"${env.CHANGE_TARGET}".trim().isEmpty()
-	echo "${env.CHANGE_TARGET}"
-	echo "${env.CHANGE_TARGET}".trim()
-	echo "${env.CHANGE_TARGET}".trim().isEmpty()
+	boolean isPullRequest = env.CHANGE_TARGET
 	echo "Is pull request: $isPullRequest"
 
 	// evaluation of build parameters

--- a/vars/emailNotification.groovy
+++ b/vars/emailNotification.groovy
@@ -1,4 +1,4 @@
-def call(def defaultRecipient) {
+def call(def defaultRecipient, def skipNotification = false) {
     def currentResult = currentBuild.result ?: 'SUCCESS'
 	def previousResult = currentBuild.previousBuild?.result ?: 'SUCCESS'
 

--- a/vars/emailNotification.groovy
+++ b/vars/emailNotification.groovy
@@ -1,0 +1,51 @@
+def call(def defaultRecipient) {
+    def currentResult = currentBuild.result ?: 'SUCCESS'
+	def previousResult = currentBuild.previousBuild?.result ?: 'SUCCESS'
+
+	if (!skipNotification) {
+		if (currentResult == 'FAILURE') {
+			notifyFailure(defaultRecipient)
+		} else if (currentResult == 'SUCCESS' && previouslyFailed()) {
+			notifyFix(defaultRecipient)
+		}
+	}
+}
+
+def notifyFix(defaultRecipient) {
+	notify(defaultRecipient, 'FIXED', 'fixed previous build errors')
+}
+
+def notifyFailure(defaultRecipient) {
+	notify(defaultRecipient, 'FAILED', 'failed')
+}
+
+def notify(defaultRecipient, token, verb) {
+	node {
+		wrap([$class: 'MaskPasswordsBuildWrapper', varMaskRegexes: [
+			[regex: '@[^\\s,]+']
+		]]) {
+			emailext([
+				attachLog: true,
+				body: "The build of ${JOB_NAME} #${BUILD_NUMBER} ${verb}.\nPlease visit ${BUILD_URL} for details.",
+				subject: "${token}: build of ${JOB_NAME} #${BUILD_NUMBER}",
+				to: defaultRecipient,
+				recipientProviders: [[$class: 'RequesterRecipientProvider'], [$class:'CulpritsRecipientProvider']]
+			])
+		}
+	}
+
+}
+
+def previouslyFailed() {
+	for (buildObject = currentBuild.previousBuild; buildObject != null; buildObject = buildObject.previousBuild) {
+		if (buildObject.result == null) {
+			continue
+		}
+		if (buildObject.result == 'FAILURE') {
+			return true
+		}
+		if (buildObject.resultIsBetterOrEqualTo('UNSTABLE')) {
+			return false
+		}
+	}
+}

--- a/vars/mdsdToolsEclipsePipeline.groovy
+++ b/vars/mdsdToolsEclipsePipeline.groovy
@@ -1,0 +1,13 @@
+def call(body) {
+	
+	final MAIL_DEFAULT_RECIPIENT = new String('c3RlcGhhbi5zZWlmZXJtYW5uQGtpdC5lZHU='.decodeBase64())
+	final BUILD_IMAGE = 'maven:3-jdk-11'
+	final BUILD_LIMIT_TIME = 30
+	final BUILD_LIMIT_RAM = '4G'
+	final BUILD_LIMIT_HDD = '20G'
+	final SSH_NAME = 'web'
+	final WEB_ROOT = '/home/deploy/html'
+	
+	slaveEclipsePipeline(body, SSH_NAME, WEB_ROOT, MAIL_DEFAULT_RECIPIENT, BUILD_IMAGE, BUILD_LIMIT_TIME, BUILD_LIMIT_RAM, BUILD_LIMIT_HDD)
+
+}

--- a/vars/mdsdToolsEclipsePipeline.groovy
+++ b/vars/mdsdToolsEclipsePipeline.groovy
@@ -1,6 +1,6 @@
 def call(body) {
 	
-	final MAIL_DEFAULT_RECIPIENT = new String('c3RlcGhhbi5zZWlmZXJtYW5uQGtpdC5lZHU='.decodeBase64())
+	final MAIL_DEFAULT_RECIPIENT = new String('bWRzZC10b29scy1idWlsZEBpcmEudWthLmRl'.decodeBase64())
 	final BUILD_IMAGE = 'maven:3-jdk-11'
 	final BUILD_LIMIT_TIME = 30
 	final BUILD_LIMIT_RAM = '4G'

--- a/vars/slaveEclipsePipeline.groovy
+++ b/vars/slaveEclipsePipeline.groovy
@@ -20,7 +20,7 @@ def call(body, sshName, webRoot, fallbackRecipient, buildImage = 'maven:3-jdk-11
 			error "Missing mandatory parameter $mandatoryParameter"
 		}
 	}
-	String defaultRecipient = config.containsKey('defaultRecipient') ? config.get('defaultRecipient').toString().trim() : fallbackRecipient
+	String defaultRecipient = config.containsKey('defaultRecipient') ? decodeEmailAddress(config.get('defaultRecipient')) : fallbackRecipient
 	boolean skipCodeQuality = config.containsKey('skipCodeQuality') && config.get('skipCodeQuality').toString().trim().toBoolean()
 	boolean skipNotification = config.containsKey('skipNotification') && config.get('skipNotification').toString().trim().toBoolean()
 	boolean doReleaseBuild = params.Release.toString().toBoolean()
@@ -238,3 +238,7 @@ def call(body, sshName, webRoot, fallbackRecipient, buildImage = 'maven:3-jdk-11
 	}
 
 }
+
+def decodeEmailAddress(configParameter) {
+	return configParameter.contains('@') ? configParameter : new String(configParameter.decodeBase64())
+]

--- a/vars/slaveEclipsePipeline.groovy
+++ b/vars/slaveEclipsePipeline.groovy
@@ -1,4 +1,4 @@
-def call(body, sshName, webRoot, defaultRecipient, buildImage = 'maven:3-jdk-11', buildLimitTime = 30, buildLimitRam = '4G', buildLimitHdd = '20G') {
+def call(body, sshName, webRoot, fallbackRecipient, buildImage = 'maven:3-jdk-11', buildLimitTime = 30, buildLimitRam = '4G', buildLimitHdd = '20G') {
 
 	// mandatory framework stuff
 	def config = [:]
@@ -20,6 +20,7 @@ def call(body, sshName, webRoot, defaultRecipient, buildImage = 'maven:3-jdk-11'
 			error "Missing mandatory parameter $mandatoryParameter"
 		}
 	}
+	String defaultRecipient = config.containsKey('defaultRecipient') ? config.get('defaultRecipient').toString().trim() : fallbackRecipient
 	boolean skipCodeQuality = config.containsKey('skipCodeQuality') && config.get('skipCodeQuality').toString().trim().toBoolean()
 	boolean skipNotification = config.containsKey('skipNotification') && config.get('skipNotification').toString().trim().toBoolean()
 	boolean doReleaseBuild = params.Release.toString().toBoolean()

--- a/vars/slaveEclipsePipeline.groovy
+++ b/vars/slaveEclipsePipeline.groovy
@@ -241,4 +241,4 @@ def call(body, sshName, webRoot, fallbackRecipient, buildImage = 'maven:3-jdk-11
 
 def decodeEmailAddress(configParameter) {
 	return configParameter.contains('@') ? configParameter : new String(configParameter.decodeBase64())
-]
+}


### PR DESCRIPTION
This is the initial implementation of the shared library to be used by the mdsd.tools builds. It covers
* checkout
* build
* quality checks
* deployment
* notifications

The steps are executed on slaves instead of the master. This allows us to use cheap hosts as build slaves and a more reliable host as master.

Builds are done inside of a docker container using Java 11. The container has limitations in time, usable hdd, and ram. This is important to prevent malicious pull requests from breaking the slave. All builds that are not pull requests can write to a shared maven cache, while pull requests can only read the cache.

As part of quality metrics, we collect Javadoc, checkstyle issues, junit results, and jacoco coverage.

The deployment takes place via SSH. If a release is scheduled, the nightly build will be copied to a named release folder and a shell script will be executed that generated a composite update site for all releases.

If a build fails, the last committer and a default recipient will be notified. If the build continues to fail, all commiters since the initial broken commit will be notified.

A demonstration of the running script is available on the [build host](https://build.mdsd.tools/job/MDSD-Tools/job/CDODebugUtils/job/jenkinsfile/). We should clean up the [deployment target](https://updatesite.mdsd.tools/) after merging of this PR.

@sdkrach You are familar with fancy programming languages. You might have better ideas on how to structure and clean up the code.

If we merge this PR, I prefer a squash merge because creating this pipeline required some heavy use of try and error. Single commits are mostly nonsense.