### PR TITLE
Keep last 100 build logs

### DIFF
--- a/vars/slaveEclipsePipeline.groovy
+++ b/vars/slaveEclipsePipeline.groovy
@@ -46,7 +46,7 @@ def call(body, sshName, webRoot, fallbackRecipient, buildImage = 'maven:3-jdk-11
 					string(defaultValue: 'nightly', name: 'ReleaseVersion', description: 'Set version to be used for the release')
 				]),
 				// define log rotation
-				buildDiscarder(logRotator(artifactDaysToKeepStr: '1', artifactNumToKeepStr: '', daysToKeepStr: '7', numToKeepStr: '')),
+				buildDiscarder(logRotator(artifactDaysToKeepStr: '1', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '100')),
 			])
 
 			node('docker') {


### PR DESCRIPTION
At the moment, build logs are deleted after 7 days. It would be better to keep them until a threshold is reached.