### PR TITLE
MNG-6642 breaks tycho, therefore roll-back to 3.6.0

### DIFF
--- a/vars/slaveEclipsePipeline.groovy
+++ b/vars/slaveEclipsePipeline.groovy
@@ -1,4 +1,4 @@
-def call(body, sshName, webRoot, fallbackRecipient, buildImage = 'maven:3-jdk-11', buildLimitTime = 30, buildLimitRam = '4G', buildLimitHdd = '20G') {
+def call(body, sshName, webRoot, fallbackRecipient, buildImage = 'maven:3.6.0-jdk-11', buildLimitTime = 30, buildLimitRam = '4G', buildLimitHdd = '20G') {
 
 	// mandatory framework stuff
 	def config = [:]


### PR DESCRIPTION
see discussion in [Eclipse bug tracker](https://bugs.eclipse.org/bugs/show_bug.cgi?id=546463)