### PR TITLE
Add sonatype deployment

### DIFF
--- a/resources/tools/mdsd/devops/pipeline/stages/impl/deploy/sonatype/modules/Container/BuildInContainer.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/deploy/sonatype/modules/Container/BuildInContainer.groovy
@@ -1,0 +1,7 @@
+if (CFG.sonatypeDeploymentActive) {
+	sh "docker exec ${CFG.containerId} mkdir /tmp/.gnupg"
+	sh "docker exec ${CFG.containerId} chmod 700 /tmp/.gnupg"
+	sh "docker exec ${CFG.containerId} gpg --batch --import /gpg.sec"
+}
+
+MPLModule('Build In Container')

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/deploy/sonatype/modules/Container/BuildInContainer.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/deploy/sonatype/modules/Container/BuildInContainer.groovy
@@ -1,7 +1,7 @@
 if (CFG.sonatypeDeploymentActive) {
-	sh "docker exec ${CFG.containerId} mkdir /tmp/.gnupg"
-	sh "docker exec ${CFG.containerId} chmod 700 /tmp/.gnupg"
-	sh "docker exec ${CFG.containerId} gpg --batch --import /gpg.sec"
+    sh "docker exec ${CFG.containerId} mkdir /tmp/.gnupg"
+    sh "docker exec ${CFG.containerId} chmod 700 /tmp/.gnupg"
+    sh "docker exec ${CFG.containerId} gpg --batch --import /gpg.sec"
 }
 
 MPLModule('Build In Container')

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/deploy/sonatype/modules/Container/SetupContainer.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/deploy/sonatype/modules/Container/SetupContainer.groovy
@@ -1,0 +1,10 @@
+MPLModule('Setup Container')
+
+if (CFG.sonatypeDeploymentActive) {
+	CFG = getCurrentConfiguration()
+	extendConfiguration([dockerWithRunParameters: """\
+		-e GNUPGHOME=/tmp/.gnupg \
+		-v ${CFG.gpgKeyFile}:/gpg.sec:ro \
+		${CFG.dockerWithRunParameters} \
+		"""])
+}

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/deploy/sonatype/modules/Container/SetupContainer.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/deploy/sonatype/modules/Container/SetupContainer.groovy
@@ -1,10 +1,10 @@
 MPLModule('Setup Container')
 
 if (CFG.sonatypeDeploymentActive) {
-	CFG = getCurrentConfiguration()
-	extendConfiguration([dockerWithRunParameters: """\
-		-e GNUPGHOME=/tmp/.gnupg \
-		-v ${CFG.gpgKeyFile}:/gpg.sec:ro \
-		${CFG.dockerWithRunParameters} \
-		"""])
+    CFG = getCurrentConfiguration()
+    extendConfiguration([dockerWithRunParameters: """\
+        -e GNUPGHOME=/tmp/.gnupg \
+        -v ${CFG.gpgKeyFile}:/gpg.sec:ro \
+        ${CFG.dockerWithRunParameters} \
+        """])
 }

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/deploy/sonatype/modules/Deploy/SonatypeDeploy.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/deploy/sonatype/modules/Deploy/SonatypeDeploy.groovy
@@ -1,0 +1,25 @@
+if (!CFG.deploySonatypeSettingsId) {
+	error 'A maven settings file id is mandatory for sonatype deployments.'
+}
+if (!CFG.deploySonatypeGpgId) {
+	error 'A GPG key file id is mandatory for sonatype deployments.'
+}
+
+extendConfiguration([
+	sonatypeDeploymentActive: true, 
+	mavenSettingsId: CFG.deploySonatypeSettingsId,
+	mavenGoal: "clean deploy -Plocal-build-deployable",
+	skipCacheWriteBack: true,
+	dockerWithRunParameters: "",
+	dockerBuildImage: "",
+	dockerWithRunParameters: "",
+	containerId: ""
+])
+
+CFG = getCurrentConfiguration()
+
+configFileProvider(
+	[configFile(fileId: CFG.deploySonatypeGpgId, variable: 'GPG_KEY')]) {
+	extendConfiguration([gpgKeyFile: GPG_KEY])
+	MPLModule("Build")
+}

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/deploy/sonatype/modules/Deploy/SonatypeDeploy.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/deploy/sonatype/modules/Deploy/SonatypeDeploy.groovy
@@ -1,25 +1,25 @@
 if (!CFG.deploySonatypeSettingsId) {
-	error 'A maven settings file id is mandatory for sonatype deployments.'
+    error 'A maven settings file id is mandatory for sonatype deployments.'
 }
 if (!CFG.deploySonatypeGpgId) {
-	error 'A GPG key file id is mandatory for sonatype deployments.'
+    error 'A GPG key file id is mandatory for sonatype deployments.'
 }
 
 extendConfiguration([
-	sonatypeDeploymentActive: true, 
-	mavenSettingsId: CFG.deploySonatypeSettingsId,
-	mavenGoal: "clean deploy -Plocal-build-deployable",
-	skipCacheWriteBack: true,
-	dockerWithRunParameters: "",
-	dockerBuildImage: "",
-	dockerWithRunParameters: "",
-	containerId: ""
+    sonatypeDeploymentActive: true,
+    mavenSettingsId: CFG.deploySonatypeSettingsId,
+    mavenGoal: "clean deploy -Plocal-build-deployable",
+    skipCacheWriteBack: true,
+    dockerWithRunParameters: "",
+    dockerBuildImage: "",
+    dockerWithRunParameters: "",
+    containerId: ""
 ])
 
 CFG = getCurrentConfiguration()
 
 configFileProvider(
-	[configFile(fileId: CFG.deploySonatypeGpgId, variable: 'GPG_KEY')]) {
-	extendConfiguration([gpgKeyFile: GPG_KEY])
-	MPLModule("Build")
-}
+        [configFile(fileId: CFG.deploySonatypeGpgId, variable: 'GPG_KEY')]) {
+            extendConfiguration([gpgKeyFile: GPG_KEY])
+            MPLModule("Build")
+        }

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/deploy/sonatype/modules/Deploy/SonatypeDeploy.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/deploy/sonatype/modules/Deploy/SonatypeDeploy.groovy
@@ -18,8 +18,7 @@ extendConfiguration([
 
 CFG = getCurrentConfiguration()
 
-configFileProvider(
-        [configFile(fileId: CFG.deploySonatypeGpgId, variable: 'GPG_KEY')]) {
-            extendConfiguration([gpgKeyFile: GPG_KEY])
-            MPLModule("Build")
-        }
+configFileProvider([configFile(fileId: CFG.deploySonatypeGpgId, variable: 'GPG_KEY')]) {
+    extendConfiguration([gpgKeyFile: GPG_KEY])
+    MPLModule("Build")
+}

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/maven/modules/Build/ApplySettingsAndBuild.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/maven/modules/Build/ApplySettingsAndBuild.groovy
@@ -1,0 +1,12 @@
+def mavenSettingsFile = "${CFG.emptySlaveDir}/emptyFile"
+
+if (CFG.mavenSettingsId) {
+	configFileProvider(
+		[configFile(fileId: CFG.mavenSettingsId, variable: 'MAVEN_SETTINGS')]) {
+		extendConfiguration([mavenSettingsFile: MAVEN_SETTINGS])
+		MPLModule("Build")
+	}
+} else {
+	sh "touch ${mavenSettingsFile}"
+	MPLModule("Build")
+}

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/maven/modules/Build/ApplySettingsAndBuild.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/maven/modules/Build/ApplySettingsAndBuild.groovy
@@ -1,12 +1,12 @@
 def mavenSettingsFile = "${CFG.emptySlaveDir}/emptyFile"
 
 if (CFG.mavenSettingsId) {
-	configFileProvider(
-		[configFile(fileId: CFG.mavenSettingsId, variable: 'MAVEN_SETTINGS')]) {
-		extendConfiguration([mavenSettingsFile: MAVEN_SETTINGS])
-		MPLModule("Build")
-	}
+    configFileProvider(
+            [configFile(fileId: CFG.mavenSettingsId, variable: 'MAVEN_SETTINGS')]) {
+                extendConfiguration([mavenSettingsFile: MAVEN_SETTINGS])
+                MPLModule("Build")
+            }
 } else {
-	sh "touch ${mavenSettingsFile}"
-	MPLModule("Build")
+    sh "touch ${mavenSettingsFile}"
+    MPLModule("Build")
 }

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/maven/modules/Build/Build.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/maven/modules/Build/Build.groovy
@@ -1,16 +1,1 @@
-configFileProvider(
-    [configFile(fileId: 'fba2768e-c997-4043-b10b-b5ca461aff54', variable: 'MAVEN_SETTINGS')]) {
-    extendConfiguration([
-        mavenSettingsFile: MAVEN_SETTINGS,
-        emptySlaveDir: "/tmp/${env.BUILD_TAG}"])
-
-    CFG = getCurrentConfiguration()
-
-    MPLModulePostStep {
-        sh "rm -rf ${CFG.emptySlaveDir}"
-    }
-
-    sh "mkdir -p ${CFG.emptySlaveDir}"
-
-    MPLModule("Build")
-}
+MPLModule('Prepare Empty Folder For Build')

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/maven/modules/Build/Build.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/maven/modules/Build/Build.groovy
@@ -1,1 +1,2 @@
 MPLModule('Prepare Empty Folder For Build')
+MPLModule('Apply Settings And Build')

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/maven/modules/Build/PrepareEmptyFolderForBuild.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/maven/modules/Build/PrepareEmptyFolderForBuild.groovy
@@ -1,0 +1,12 @@
+extendConfiguration([
+	emptySlaveDir: "/tmp/${env.BUILD_TAG}"])
+
+CFG = getCurrentConfiguration()
+
+MPLModulePostStep {
+	sh "rm -rf \"${CFG.emptySlaveDir}\""
+}
+
+sh "mkdir -p \"${CFG.emptySlaveDir}\""
+
+MPLModule('Apply Settings And Build')

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/maven/modules/Build/PrepareEmptyFolderForBuild.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/maven/modules/Build/PrepareEmptyFolderForBuild.groovy
@@ -8,5 +8,3 @@ MPLModulePostStep {
 }
 
 sh "mkdir -p \"${CFG.emptySlaveDir}\""
-
-MPLModule('Apply Settings And Build')

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/maven/modules/Build/PrepareEmptyFolderForBuild.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/maven/modules/Build/PrepareEmptyFolderForBuild.groovy
@@ -1,10 +1,10 @@
 extendConfiguration([
-	emptySlaveDir: "/tmp/${env.BUILD_TAG}"])
+    emptySlaveDir: "/tmp/${env.BUILD_TAG}"])
 
 CFG = getCurrentConfiguration()
 
 MPLModulePostStep {
-	sh "rm -rf \"${CFG.emptySlaveDir}\""
+    sh "rm -rf \"${CFG.emptySlaveDir}\""
 }
 
 sh "mkdir -p \"${CFG.emptySlaveDir}\""

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/maven/modules/Container/BuildInContainer.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/maven/modules/Container/BuildInContainer.groovy
@@ -1,10 +1,15 @@
+def mavenGoal = "clean verify"
+if (CFG.mavenGoal) {
+	mavenGoal = CFG.mavenGoal
+}
+
 lock("m2-cache-${CFG.slaveName}") {
     sh "docker exec ${CFG.containerId} cp -r /.m2 /tmp"
 }
 sh "docker exec ${CFG.containerId} cp -r /ws /tmp"
-sh "docker exec ${CFG.containerId} mvn -Dbnd.home.dir=/tmp -s /settings.xml -f /tmp/ws/pom.xml clean verify"
+sh "docker exec ${CFG.containerId} mvn -Dbnd.home.dir=/tmp -s /settings.xml -f /tmp/ws/pom.xml ${mavenGoal}"
 sh "docker cp ${CFG.containerId}:/tmp/ws/. ${CFG.workspacePath}"
-if (!CFG.isPullRequest) {
+if (!CFG.isPullRequest && !CFG.skipCacheWriteBack) {
     lock("m2-cache-${CFG.slaveName}") {
         sh "docker cp ${CFG.containerId}:/tmp/.m2/. ${CFG.slaveHome}/.m2"
     }

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Archive/Archive.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Archive/Archive.groovy
@@ -1,1 +1,3 @@
-archiveArtifacts "${CFG.archiveArtifactsDir}/**/*"
+if (CFG.archiveArtifactsDir) {
+	archiveArtifacts "${CFG.archiveArtifactsDir}/**/*"
+}

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Archive/Archive.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Archive/Archive.groovy
@@ -1,3 +1,3 @@
 if (CFG.archiveArtifactsDir) {
-	archiveArtifacts "${CFG.archiveArtifactsDir}/**/*"
+    archiveArtifacts "${CFG.archiveArtifactsDir}/**/*"
 }

--- a/vars/MDSDToolsPipeline.groovy
+++ b/vars/MDSDToolsPipeline.groovy
@@ -5,6 +5,8 @@ def call(body) {
         buildWithMaven {
             version = '3.6.0'
             jdkVersion = 11
+			settingsId = 'fba2768e-c997-4043-b10b-b5ca461aff54'
+			goal = 'clean verify'
         }
 
         constraintBuild {

--- a/vars/MDSDToolsPipeline.groovy
+++ b/vars/MDSDToolsPipeline.groovy
@@ -5,8 +5,8 @@ def call(body) {
         buildWithMaven {
             version = '3.6.0'
             jdkVersion = 11
-			settingsId = 'fba2768e-c997-4043-b10b-b5ca461aff54'
-			goal = 'clean verify'
+            settingsId = 'fba2768e-c997-4043-b10b-b5ca461aff54'
+            goal = 'clean verify'
         }
 
         constraintBuild {


### PR DESCRIPTION
The PR adds the deployment type `sonatype`. Basically, it runs a regular dockerized maven build and repeats this step during the deployment phase. However, during deployment, configuration files containing credentials and signing keys are added. Deployment is done via maven.

The maven build is reused. I had to reset configurations made by previous stages. My solution works but breaks encapsulation of business logic. However, I do not see another option of doing this. You, @sdkrach, might have a better idea.