### PR TITLE
Reintroduced latest folder

### DIFF
--- a/resources/tools/mdsd/devops/pipeline/stages/impl/deploy/updatesite/modules/Deploy/SSHUpdatesiteReleaseDeploy.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/deploy/updatesite/modules/Deploy/SSHUpdatesiteReleaseDeploy.groovy
@@ -25,6 +25,8 @@ configFileProvider(
                                 "cd ${CFG.deployUpdatesiteRootDir}/${CFG.deployUpdatesiteProjectDir} && " +
                                 "mkdir -p releases/${CFG.deployReleaseVersion} && " +
                                 "cp -a ${CFG.deployUpdatesiteSubDir}/* releases/${CFG.deployReleaseVersion}/ && " +
+                                "rm -rf releases/latest && " +
+                                "ln -s releases/${CFG.deployReleaseVersion} releases/latest && " +
                                 "chmod +x $SCRIPTNAME && " +
                                 "./$SCRIPTNAME releases && " +
                                 "rm $SCRIPTNAME"


### PR DESCRIPTION
For several reasons, it is still beneficial to have a latest folder instead of only a composite update site in the releases folder. One example are non-updatesite artifacts such as products. Another benefit is to be sure that only the really latest artifacts will be used when referring to the latest update site. Otherwise, issues like missing artifacts might be hidden.