### PR TITLE
Pass release flag to container

### DIFF
--- a/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/maven/modules/Container/BuildInContainer.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/maven/modules/Container/BuildInContainer.groovy
@@ -1,6 +1,10 @@
 def mavenGoal = "clean verify"
 if (CFG.mavenGoal) {
-	mavenGoal = CFG.mavenGoal
+    mavenGoal = CFG.mavenGoal
+}
+
+if (CFG.deployRelease) {
+    mavenGoal = "-Drelease ${mavenGoal}"
 }
 
 lock("m2-cache-${CFG.slaveName}") {

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/modules/Container/SetupContainer.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/modules/Container/SetupContainer.groovy
@@ -2,6 +2,7 @@ extendConfiguration([dockerWithRunParameters: """\
         ${CFG.dockerWithRunParameters ?: ""} \
         -u ${CFG.slaveUid} \
         -v ${CFG.workspacePath}:/ws:ro \
+        -e "RELEASE=${CFG.deployRelease}"
         --network proxy \
         -it \
         --entrypoint=/bin/cat \

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/modules/Container/SetupContainer.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/modules/Container/SetupContainer.groovy
@@ -2,7 +2,7 @@ extendConfiguration([dockerWithRunParameters: """\
         ${CFG.dockerWithRunParameters ?: ""} \
         -u ${CFG.slaveUid} \
         -v ${CFG.workspacePath}:/ws:ro \
-        -e "RELEASE=${CFG.deployRelease}"
+        -e "RELEASE=${CFG.deployRelease}" \
         --network proxy \
         -it \
         --entrypoint=/bin/cat \


### PR DESCRIPTION
The release environment variable is not passed to the docker container. However, in some cases we need this information there.

Please update the build server configuration to `master` after merging this pull request but before deleting the branch.