### PR TITLE
Update entry page of JavaDoc

### DIFF
--- a/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Metrics/PublishJavaDocQualityMetrics.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Metrics/PublishJavaDocQualityMetrics.groovy
@@ -4,7 +4,7 @@ if (CFG.javadocArtifactsDir) {
         alwaysLinkToLastBuild: false,
         keepAll: false,
         reportDir: "${CFG.javadocArtifactsDir}",
-        reportFiles: 'overview-summary.html',
+        reportFiles: 'index.html',
         reportName: 'JavaDoc',
         reportTitles: ''
     ])


### PR DESCRIPTION
The old code refers to the file overview-summary.html, which has been the frameless version in JDK 8. Later versions are always frameless. Now, the index.html file is the correct entry page. The other file just redirects to the index.html.