### PR TITLE
Add environment variable for proxy usage

### DIFF
--- a/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/maven/modules/Container/SetupContainer.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/maven/modules/Container/SetupContainer.groovy
@@ -10,6 +10,7 @@ extendConfiguration([
     -v ${CFG.mavenSettingsFile}:/settings.xml:ro \
     -e MAVEN_CONFIG=/tmp/.m2 \
     -e MAVEN_OPTS=-Duser.home=/tmp \
+    -e USE_PROXY=true \
     """])
 
 MPLModule('Setup Container')


### PR DESCRIPTION
We have some build scripts that cannot be properly configured via maven settings to use our http proxy on the build server. This holds for all scripts that make use of the tycho eclipse run plugin. We used an environment variable on our old build server but failed to integrate this feature in our new modularized pipeline. This PR introduces the environment variable.

I configured the Palladio build server to use this branch in order to test if it works correctly. So far, all looks good.