### PR TITLE
Fix deployment location

### DIFF
--- a/vars/MDSDToolsPipeline.groovy
+++ b/vars/MDSDToolsPipeline.groovy
@@ -19,7 +19,7 @@ def call(body) {
         skipNotification ("${this.BRANCH_NAME}" != 'master')
         
         deployUpdatesiteSshName 'web'
-        deployUpdatesiteRootDir '/home/deploy/html'
+        deployUpdatesiteRootDir '/home/sftp/data'
         deployUpdatesiteSubDir ("${this.BRANCH_NAME}" == 'master' ? 'nightly': "branches/${this.BRANCH_NAME}")
         deployUpdatesiteProjectDir this.scm.userRemoteConfigs[0].url.replaceFirst(/^.*\/([^\/]+?).git$/, '$1').toLowerCase()
 


### PR DESCRIPTION
This PR adjusts the deployment location to the new infrastructure (moved from bwCloud to KIT infrastructure).

The error only appears when releasing a bundle (see [last log](https://build.mdsd.tools/job/MDSD-Tools/job/Library-StandaloneInitialization/job/master/2/console)).