### PR TITLE
Added singleArtifactDeploy option to sonatype

### DIFF
--- a/resources/tools/mdsd/devops/pipeline/stages/impl/deploy/sonatype/modules/Deploy/SonatypeDeploy.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/deploy/sonatype/modules/Deploy/SonatypeDeploy.groovy
@@ -5,10 +5,15 @@ if (!CFG.deploySonatypeGpgId) {
     error 'A GPG key file id is mandatory for sonatype deployments.'
 }
 
+def mavenDeployGoal = "clean deploy -Plocal-build-deployable"
+if (CFG.deploySonatypeSingleArtifactDeploy) {
+    mavenDeployGoal = "gpg:sign-and-deploy-file -Psonatype-single-artifact-deploy"
+}
+
 extendConfiguration([
     sonatypeDeploymentActive: true,
     mavenSettingsId: CFG.deploySonatypeSettingsId,
-    mavenGoal: "clean deploy -Plocal-build-deployable",
+    mavenGoal: "${mavenDeployGoal}",
     skipCacheWriteBack: true,
     dockerWithRunParameters: "",
     dockerBuildImage: "",


### PR DESCRIPTION
Added support to existing sonatype deploy stage. Configuration of the gpg plugin is done in the projects parent pom. This allows us to access groupid and version. No changes to the settings.xml are required.

The following branch is getting its snapshots deployed using this branch. 
https://github.com/PalladioSimulator/Palladio-Addons-TextBasedModelGenerator/tree/tpcmDraft
https://oss.sonatype.org/content/repositories/snapshots/org/palladiosimulator/textual/tpcm-language-server