### PR TITLE
Treat main as master

### DIFF
--- a/vars/AbstractMDSDToolsPipeline.groovy
+++ b/vars/AbstractMDSDToolsPipeline.groovy
@@ -49,7 +49,7 @@ def call(defaults  = [:], overrides = [:]) {
         steps {
           extendConfiguration([
             workspacePath: pwd(),
-            isMasterBranch: "$BRANCH_NAME" == 'master',
+            isMasterBranch: "$BRANCH_NAME" in ['master', 'main'],
             isPullRequest: !(env.CHANGE_TARGET == null)
           ])
           MPLModule()

--- a/vars/AbstractMDSDToolsPipeline.groovy
+++ b/vars/AbstractMDSDToolsPipeline.groovy
@@ -49,7 +49,7 @@ def call(defaults  = [:], overrides = [:]) {
         steps {
           extendConfiguration([
             workspacePath: pwd(),
-            isMasterBranch: "$BRANCH_NAME" in ['master', 'main'],
+            isMasterBranch: ['master', 'main'].find{it == "$BRANCH_NAME"},
             isPullRequest: !(env.CHANGE_TARGET == null)
           ])
           MPLModule()

--- a/vars/AbstractMDSDToolsPipeline.groovy
+++ b/vars/AbstractMDSDToolsPipeline.groovy
@@ -49,7 +49,7 @@ def call(defaults  = [:], overrides = [:]) {
         steps {
           extendConfiguration([
             workspacePath: pwd(),
-            isMasterBranch: ['master', 'main'].find{it == "$BRANCH_NAME"},
+            isMasterBranch: ['master', 'main'].find{it == "$BRANCH_NAME"} != null,
             isPullRequest: !(env.CHANGE_TARGET == null)
           ])
           MPLModule()

--- a/vars/MDSDToolsPipeline.groovy
+++ b/vars/MDSDToolsPipeline.groovy
@@ -15,12 +15,12 @@ def call(body) {
             hddLimit = '20G'
         }
         
-        skipDeploy (!['master', 'main'].find{it == "${this.BRANCH_NAME}"})
-        skipNotification (!['master', 'main'].find{it == "${this.BRANCH_NAME}"})
+        skipDeploy (['master', 'main'].find{it == "${this.BRANCH_NAME}"} == null)
+        skipNotification (['master', 'main'].find{it == "${this.BRANCH_NAME}"} == null)
         
         deployUpdatesiteSshName 'web'
         deployUpdatesiteRootDir '/home/sftp/data'
-        deployUpdatesiteSubDir (['master', 'main'].find{it == "${this.BRANCH_NAME}"} ? 'nightly': "branches/${this.BRANCH_NAME}")
+        deployUpdatesiteSubDir (['master', 'main'].find{it == "${this.BRANCH_NAME}"} != null ? 'nightly': "branches/${this.BRANCH_NAME}")
         deployUpdatesiteProjectDir this.scm.userRemoteConfigs[0].url.replaceFirst(/^.*\/([^\/]+?).git$/, '$1').toLowerCase()
 
         createCompositeUpdatesiteScriptFileId '57dc902b-f5a7-49a9-aec3-98deabe48580'

--- a/vars/MDSDToolsPipeline.groovy
+++ b/vars/MDSDToolsPipeline.groovy
@@ -15,12 +15,12 @@ def call(body) {
             hddLimit = '20G'
         }
         
-        skipDeploy (!("${this.BRANCH_NAME}" in ['master', 'main']))
-        skipNotification (!("${this.BRANCH_NAME}" in ['master', 'main']))
+        skipDeploy (!['master', 'main'].find{it == "${this.BRANCH_NAME}"})
+        skipNotification (!['master', 'main'].find{it == "${this.BRANCH_NAME}"})
         
         deployUpdatesiteSshName 'web'
         deployUpdatesiteRootDir '/home/sftp/data'
-        deployUpdatesiteSubDir ("${this.BRANCH_NAME}" in ['master', 'main'] ? 'nightly': "branches/${this.BRANCH_NAME}")
+        deployUpdatesiteSubDir (['master', 'main'].find{it == "${this.BRANCH_NAME}"} ? 'nightly': "branches/${this.BRANCH_NAME}")
         deployUpdatesiteProjectDir this.scm.userRemoteConfigs[0].url.replaceFirst(/^.*\/([^\/]+?).git$/, '$1').toLowerCase()
 
         createCompositeUpdatesiteScriptFileId '57dc902b-f5a7-49a9-aec3-98deabe48580'

--- a/vars/MDSDToolsPipeline.groovy
+++ b/vars/MDSDToolsPipeline.groovy
@@ -15,12 +15,12 @@ def call(body) {
             hddLimit = '20G'
         }
         
-        skipDeploy ("${this.BRANCH_NAME}" != 'master')
-        skipNotification ("${this.BRANCH_NAME}" != 'master')
+        skipDeploy ("${this.BRANCH_NAME}" !in ['master', 'main'])
+        skipNotification ("${this.BRANCH_NAME}" !in ['master', 'main'])
         
         deployUpdatesiteSshName 'web'
         deployUpdatesiteRootDir '/home/sftp/data'
-        deployUpdatesiteSubDir ("${this.BRANCH_NAME}" == 'master' ? 'nightly': "branches/${this.BRANCH_NAME}")
+        deployUpdatesiteSubDir ("${this.BRANCH_NAME}" in ['master', 'main'] ? 'nightly': "branches/${this.BRANCH_NAME}")
         deployUpdatesiteProjectDir this.scm.userRemoteConfigs[0].url.replaceFirst(/^.*\/([^\/]+?).git$/, '$1').toLowerCase()
 
         createCompositeUpdatesiteScriptFileId '57dc902b-f5a7-49a9-aec3-98deabe48580'

--- a/vars/MDSDToolsPipeline.groovy
+++ b/vars/MDSDToolsPipeline.groovy
@@ -15,8 +15,8 @@ def call(body) {
             hddLimit = '20G'
         }
         
-        skipDeploy ("${this.BRANCH_NAME}" !in ['master', 'main'])
-        skipNotification ("${this.BRANCH_NAME}" !in ['master', 'main'])
+        skipDeploy (!("${this.BRANCH_NAME}" in ['master', 'main']))
+        skipNotification (!("${this.BRANCH_NAME}" in ['master', 'main']))
         
         deployUpdatesiteSshName 'web'
         deployUpdatesiteRootDir '/home/sftp/data'


### PR DESCRIPTION
This PR introduces support for the new Github naming policy, which uses _main_ instead of _master_ (see [documentation](https://github.com/github/renaming) for details).

This branch is used as default branch in our Jenkins build, so we have to switch back to master after merging and before deleting this branch.

Because of some try'n'error while fiddling around with Groovy, I prefer a squash merge.