### PR TITLE
Add code coverage status test in pipeline

### DIFF
--- a/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Metrics/JaCoCoQualityMetrics.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Metrics/JaCoCoQualityMetrics.groovy
@@ -10,17 +10,41 @@ jacoco([
 ])
 
 if (CFG.isPullRequest) {
-    echo "Test Coverage Debug"
-    def lastCoverageUrl = "${env.JOB_URL}../main/lastSuccessfulBuild/jacoco/api/json"
-    def response = httpRequest url: lastCoverageUrl, validResponseCodes: '100:599'
+    final COVERAGE_LEVEL = 'instructionCoverage'
+    final EPSILON = 0.1
+
+
+    echo "Collecting coverage of master branch"
+    def masterCoverageUrl = "${env.JOB_URL}../main/lastSuccessfulBuild/jacoco/api/json"
+    def response = httpRequest url: masterCoverageUrl, validResponseCodes: '100:599'
     if (!200.equals(response.status)) {
-        lastCoverageUrl = "${env.JOB_URL}../master/lastSuccessfulBuild/jacoco/api/json"
-        response = httpRequest url: lastCoverageUrl, validResponseCodes: '100:599'
+        masterCoverageUrl = "${env.JOB_URL}../master/lastSuccessfulBuild/jacoco/api/json"
+        response = httpRequest url: masterCoverageUrl, validResponseCodes: '100:599'
     }
     if (200.equals(response.status)) {
         def jsonObject = readJSON text: response.content
-        def coverage = jsonObject['instructionCoverage']['percentageFloat']
-        echo "${coverage}"
+        def masterCoverage = jsonObject[COVERAGE_LEVEL]['percentageFloat']
+        echo "Found master branch coverage ${COVERAGE_LEVEL} of ${masterCoverage}."
+
+        echo "Determining job coverage"
+        def coverageUrl = "${env.BUILD_URL}/jacoco/api/json"
+        response = httpRequest url: coverageUrl, validResponseCodes: '100:599'
+        if (200.equals(response.status)) {
+            jsonObject = readJSON text: response.content
+            def jobCoverage = jsonObject[COVERAGE_LEVEL]['percentageFloat']
+            echo "Found job coverage ${COVERAGE_LEVEL} of ${jobCoverage}."
+            if (jobCoverage - masterCoverage < -1.0 * EPSILON) {
+                echo "Coverage decreased from ${masterCoverage} to ${jobCoverage}"
+                // TODO report worsened coverage
+            } else {
+                echo "Coverage did not decrease."
+                // TODO report increased or same coverage
+            }
+        } else {
+            echo "Could not find job coverage."
+            // TODO report worsened coverage
+        }
+    } else {
+        echo "Could not find master branch coverage. Skipping coverage comparison."
     }
-    echo "${response.status}"
 }

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Metrics/JaCoCoQualityMetrics.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Metrics/JaCoCoQualityMetrics.groovy
@@ -41,42 +41,54 @@ if (CFG.isPullRequest) {
         def masterCoverage = jsonObject[COVERAGE_LEVEL]['percentageFloat']
         echo "Found master branch coverage ${COVERAGE_LEVEL} of ${masterCoverage}."
 
-        // search for job coverage
-        echo "Determining job coverage"
-        def coverageUrl = "${env.BUILD_URL}jacoco/api/json"
-        response = httpRequest url: coverageUrl, validResponseCodes: '100:599'
-        if (200.equals(response.status)) {
-            jsonObject = readJSON text: response.content
-            def jobCoverage = jsonObject[COVERAGE_LEVEL]['percentageFloat']
-            echo "Found job coverage ${COVERAGE_LEVEL} of ${jobCoverage}."
+        // only consider reference coverages greater than epsilon
+        if (masterCoverage > EPSILON) {
 
-            // comparison of job with master coverage
-            if (jobCoverage - masterCoverage < -1.0 * EPSILON) {
+            // search for job coverage
+            echo "Determining job coverage"
+            def coverageUrl = "${env.BUILD_URL}jacoco/api/json"
+            response = httpRequest url: coverageUrl, validResponseCodes: '100:599'
+            if (200.equals(response.status)) {
+                jsonObject = readJSON text: response.content
+                def jobCoverage = jsonObject[COVERAGE_LEVEL]['percentageFloat']
+                echo "Found job coverage ${COVERAGE_LEVEL} of ${jobCoverage}."
 
-                // coverage has worsened
-                echo "Coverage decreased from ${masterCoverage} to ${jobCoverage}"
-                githubNotify credentialsId: CREDENTIALS_ID,
-                             context: STATUS_CONTEXT,
-                             targetUrl: STATUS_URL,
-                             status: 'ERROR',
-                             description: "The code coverage decreased from ${masterCoverage}% to ${jobCoverage}% with respect to the ${masterBranchName} branch."
+                // comparison of job with master coverage
+                if (jobCoverage - masterCoverage < -1.0 * EPSILON) {
+
+                    // coverage has worsened
+                    echo "Coverage decreased from ${masterCoverage} to ${jobCoverage}"
+                    githubNotify credentialsId: CREDENTIALS_ID,
+                                context: STATUS_CONTEXT,
+                                targetUrl: STATUS_URL,
+                                status: 'ERROR',
+                                description: "The code coverage decreased from ${masterCoverage}% to ${jobCoverage}% with respect to the ${masterBranchName} branch."
+                } else {
+                    // coverage is better or equal
+                    echo "Coverage did not decrease."
+                    githubNotify credentialsId: CREDENTIALS_ID,
+                                context: STATUS_CONTEXT,
+                                targetUrl: STATUS_URL,
+                                status: 'SUCCESS',
+                                description: "The code coverage did not decrease with respect to the ${masterBranchName} branch."
+                }
             } else {
-                // coverage is better or equal
-                echo "Coverage did not decrease."
+                // no job coverage found
+                echo "Could not find job coverage."
                 githubNotify credentialsId: CREDENTIALS_ID,
-                             context: STATUS_CONTEXT,
-                             targetUrl: STATUS_URL,
-                             status: 'SUCCESS',
-                             description: "The code coverage did not decrease with respect to the ${masterBranchName} branch."
+                            context: STATUS_CONTEXT,
+                            targetUrl: STATUS_URL,
+                            status: 'FAILURE',
+                            description: "Code coverage of job could not be determined but there is a coverage for the ${masterBranchName} branch."
             }
         } else {
-            // no job coverage found
-            echo "Could not find job coverage."
+            // master coverage is too low to be considered
+            echo "Master coverage is below threshold."
             githubNotify credentialsId: CREDENTIALS_ID,
-                         context: STATUS_CONTEXT,
-                         targetUrl: STATUS_URL,
-                         status: 'FAILURE',
-                         description: "Code coverage of job could not be determined but there is a coverage for the ${masterBranchName} branch."
+                        context: STATUS_CONTEXT,
+                        targetUrl: STATUS_URL,
+                        status: 'SUCCESS',
+                        description: "There is no significant code coverage for the ${masterBranchName} branch, skipping coverage check."
         }
     } else {
         // no master coverage found

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Metrics/JaCoCoQualityMetrics.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Metrics/JaCoCoQualityMetrics.groovy
@@ -8,3 +8,9 @@ jacoco([
     inclusionPattern: '**/*.class',
     exclusionPattern: '**/*Test*.class'
 ])
+
+if (CFG.isPullRequest) {
+    echo "Test Coverage Debug"
+    echo "${env.BUILD_URL}"
+    echo "${env.JOB_URL}"
+}

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Metrics/JaCoCoQualityMetrics.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Metrics/JaCoCoQualityMetrics.groovy
@@ -14,7 +14,7 @@ if (CFG.isPullRequest) {
 
     // constants
     final COVERAGE_LEVEL = 'instructionCoverage'
-    final EPSILON = 0.1
+    final EPSILON = 0.001
     final STATUS_CONTEXT = 'continuous-integration/jenkins/codecoverage'
     final STATUS_URL = "${env.BUILD_URL}jacoco"
     final CREDENTIALS_ID = '8adf889c-2157-45d1-acc7-1c6211538dac'

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Metrics/JaCoCoQualityMetrics.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Metrics/JaCoCoQualityMetrics.groovy
@@ -11,8 +11,12 @@ jacoco([
 
 if (CFG.isPullRequest) {
     echo "Test Coverage Debug"
-    def lastCoverageUrl = "${env.JOB_URL}/../master/lastSuccessfulBuild/jacoco/api/json"
+    def lastCoverageUrl = "${env.JOB_URL}../main/lastSuccessfulBuild/jacoco/api/json"
     def response = httpRequest lastCoverageUrl
+    if (!200.equals(response.status)) {
+        lastCoverageUrl = "${env.JOB_URL}../master/lastSuccessfulBuild/jacoco/api/json"
+        response = httpRequest lastCoverageUrl
+    }
     if (200.equals(response.status)) {
         def jsonObject = readJSON text: response.content
         def coverage = jsonObject['instructionCoverage']['percentageFloat']

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Metrics/JaCoCoQualityMetrics.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Metrics/JaCoCoQualityMetrics.groovy
@@ -11,6 +11,14 @@ jacoco([
 
 if (CFG.isPullRequest) {
     echo "Test Coverage Debug"
-    echo "${env.BUILD_URL}"
-    echo "${env.JOB_URL}"
+    def lastCoverageUrl = "${env.JOB_URL}/../master/lastSuccessfulBuild/jacoco/api/json"
+    def get = new URL(lastCoverageUrl).openConnection();
+    def getRC = get.getResponseCode();
+    if(getRC.equals(200)) {
+        def jsonText = get.getInputStream().getText()
+        def jsonObject = readJSON text: jsonText
+        def coverage = jsonObject['instructionCoverage']['percentageFloat']
+        echo "${coverage}"
+    }
+    echo "${getRC}"
 }

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Metrics/JaCoCoQualityMetrics.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Metrics/JaCoCoQualityMetrics.groovy
@@ -12,10 +12,10 @@ jacoco([
 if (CFG.isPullRequest) {
     echo "Test Coverage Debug"
     def lastCoverageUrl = "${env.JOB_URL}../main/lastSuccessfulBuild/jacoco/api/json"
-    def response = httpRequest lastCoverageUrl
+    def response = httpRequest url: lastCoverageUrl, validResponseCodes: '100:599'
     if (!200.equals(response.status)) {
         lastCoverageUrl = "${env.JOB_URL}../master/lastSuccessfulBuild/jacoco/api/json"
-        response = httpRequest lastCoverageUrl
+        response = httpRequest url: lastCoverageUrl, validResponseCodes: '100:599'
     }
     if (200.equals(response.status)) {
         def jsonObject = readJSON text: response.content

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Metrics/JaCoCoQualityMetrics.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Metrics/JaCoCoQualityMetrics.groovy
@@ -9,14 +9,24 @@ jacoco([
     exclusionPattern: '**/*Test*.class'
 ])
 
+// perform code coverage status check for pull requests
 if (CFG.isPullRequest) {
+
+    // constants
     final COVERAGE_LEVEL = 'instructionCoverage'
     final EPSILON = 0.1
     final STATUS_CONTEXT = 'continuous-integration/jenkins/codecoverage'
     final STATUS_URL = "${env.BUILD_URL}jacoco"
     final CREDENTIALS_ID = '8adf889c-2157-45d1-acc7-1c6211538dac'
 
+    // pending notification
+    githubNotify credentialsId: CREDENTIALS_ID,
+                 context: STATUS_CONTEXT,
+                 targetUrl: STATUS_URL,
+                 status: 'PENDING',
+                 description: "Status check in progress..."
 
+    // search for master/main code coverage
     echo "Collecting coverage of master branch"
     def masterBranchName = 'main'
     def masterCoverageUrl = "${env.JOB_URL}../${masterBranchName}/lastSuccessfulBuild/jacoco/api/json"
@@ -31,6 +41,7 @@ if (CFG.isPullRequest) {
         def masterCoverage = jsonObject[COVERAGE_LEVEL]['percentageFloat']
         echo "Found master branch coverage ${COVERAGE_LEVEL} of ${masterCoverage}."
 
+        // search for job coverage
         echo "Determining job coverage"
         def coverageUrl = "${env.BUILD_URL}jacoco/api/json"
         response = httpRequest url: coverageUrl, validResponseCodes: '100:599'
@@ -38,10 +49,19 @@ if (CFG.isPullRequest) {
             jsonObject = readJSON text: response.content
             def jobCoverage = jsonObject[COVERAGE_LEVEL]['percentageFloat']
             echo "Found job coverage ${COVERAGE_LEVEL} of ${jobCoverage}."
+
+            // comparison of job with master coverage
             if (jobCoverage - masterCoverage < -1.0 * EPSILON) {
+
+                // coverage has worsened
                 echo "Coverage decreased from ${masterCoverage} to ${jobCoverage}"
-                // TODO report worsened coverage
+                githubNotify credentialsId: CREDENTIALS_ID,
+                             context: STATUS_CONTEXT,
+                             targetUrl: STATUS_URL,
+                             status: 'ERROR',
+                             description: "The code coverage decreased from ${masterCoverage} to ${jobCoverage} with respect to the ${masterBranchName} branch."
             } else {
+                // coverage is better or equal
                 echo "Coverage did not decrease."
                 githubNotify credentialsId: CREDENTIALS_ID,
                              context: STATUS_CONTEXT,
@@ -50,10 +70,21 @@ if (CFG.isPullRequest) {
                              description: "The code coverage did not decrease with respect to the ${masterBranchName} branch."
             }
         } else {
+            // no job coverage found
             echo "Could not find job coverage."
-            // TODO report worsened coverage
+            githubNotify credentialsId: CREDENTIALS_ID,
+                         context: STATUS_CONTEXT,
+                         targetUrl: STATUS_URL,
+                         status: 'FAILURE',
+                         description: "Code coverage of job could not be determined but there is a coverage for the ${masterBranchName} branch."
         }
     } else {
+        // no master coverage found
         echo "Could not find master branch coverage. Skipping coverage comparison."
+        githubNotify credentialsId: CREDENTIALS_ID,
+                     context: STATUS_CONTEXT,
+                     targetUrl: STATUS_URL,
+                     status: 'SUCCESS',
+                     description: "There is no code coverage for the ${masterBranchName} branch, skipping coverage check."
     }
 }

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Metrics/JaCoCoQualityMetrics.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Metrics/JaCoCoQualityMetrics.groovy
@@ -59,7 +59,7 @@ if (CFG.isPullRequest) {
                              context: STATUS_CONTEXT,
                              targetUrl: STATUS_URL,
                              status: 'ERROR',
-                             description: "The code coverage decreased from ${masterCoverage} to ${jobCoverage} with respect to the ${masterBranchName} branch."
+                             description: "The code coverage decreased from ${masterCoverage}% to ${jobCoverage}% with respect to the ${masterBranchName} branch."
             } else {
                 // coverage is better or equal
                 echo "Coverage did not decrease."

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Metrics/JaCoCoQualityMetrics.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Metrics/JaCoCoQualityMetrics.groovy
@@ -14,6 +14,7 @@ if (CFG.isPullRequest) {
     final EPSILON = 0.1
     final STATUS_CONTEXT = 'continuous-integration/jenkins/codecoverage'
     final STATUS_URL = "${env.BUILD_URL}jacoco"
+    final CREDENTIALS_ID = '8adf889c-2157-45d1-acc7-1c6211538dac'
 
 
     echo "Collecting coverage of master branch"
@@ -42,7 +43,8 @@ if (CFG.isPullRequest) {
                 // TODO report worsened coverage
             } else {
                 echo "Coverage did not decrease."
-                githubNotify context: STATUS_CONTEXT,
+                githubNotify credentialsId: CREDENTIALS_ID,
+                             context: STATUS_CONTEXT,
                              targetUrl: STATUS_URL,
                              status: 'SUCCESS',
                              description: "The code coverage did not decrease with respect to the ${masterBranchName} branch."

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Metrics/JaCoCoQualityMetrics.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/generic/modules/Metrics/JaCoCoQualityMetrics.groovy
@@ -12,13 +12,11 @@ jacoco([
 if (CFG.isPullRequest) {
     echo "Test Coverage Debug"
     def lastCoverageUrl = "${env.JOB_URL}/../master/lastSuccessfulBuild/jacoco/api/json"
-    def get = new URL(lastCoverageUrl).openConnection();
-    def getRC = get.getResponseCode();
-    if(getRC.equals(200)) {
-        def jsonText = get.getInputStream().getText()
-        def jsonObject = readJSON text: jsonText
+    def response = httpRequest lastCoverageUrl
+    if (200.equals(response.status)) {
+        def jsonObject = readJSON text: response.content
         def coverage = jsonObject['instructionCoverage']['percentageFloat']
         echo "${coverage}"
     }
-    echo "${getRC}"
+    echo "${response.status}"
 }


### PR DESCRIPTION
This PR introduces a code coverage status check for pull requests to the build pipeline. The reference coverage is the instruction level code coverage of the master/main branch. There are three possible results:
* success if
  * there is no code coverage on the master/main branch yet
  * the coverage did not decrease by more than the epsilon value
* error if the coverage did decrease by more than the epsilon value
* failure if the job coverage could not be determined even if there is a reference coverage

The pipeline requires the following new Jenkins plugins:
* [HTTP Request](https://plugins.jenkins.io/http_request/)
* [Pipeline GitHub Notify Step](https://plugins.jenkins.io/pipeline-githubnotify-step/)

Additionally, there has to be a username/password credential with ID _8adf889c-2157-45d1-acc7-1c6211538dac_ and a personal access token with scope _repo:status_.

I decided to implement the logic on my own because I could not get the [GitHub Pull Request Coverage Status](https://plugins.jenkins.io/github-pr-coverage-status/) plugin to run and the [GitHub Coverage Reporter](https://plugins.jenkins.io/github-coverage-reporter/) plugin seems to only support fixed thresholds and SonarQube reference values.

I tested the new logic by three steps:
* [commit](https://github.com/MDSD-Tools/Ecore-Workflow/pull/17/commits/9cf3a945fa0c4aeaaabb93a712e90de46bd5d7ef) yielding the same code coverage
* [commit](https://github.com/MDSD-Tools/Ecore-Workflow/pull/17/commits/b1b2e269157506336fed995647710b579aceb226) decreasing the code coverage
* [commit](https://github.com/MDSD-Tools/Library-EMFEditUtils/pull/1/commits/82bc9dd620158fcca4f9f4b4308d541ebefc31bc) without existing reference coverage

After merging the request, the pull requests MDSD-Tools/Ecore-Workflow#17 and MDSD-Tools/Library-EMFEditUtils#1 and the corresponding branches should be deleted. Additionally, we have to switch back to using the master pipeline.

Open points:
* The code could, most probably, be improved with a bit more Groovy skills.
* We might want to use another coverage metric (now: indstruction level).
* We might want to use a squash merge to hide the try and error approach in the commit log ;)