### PR TITLE
Enable latest Maven 3 image

### DIFF
--- a/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/modules/Build/Build.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/modules/Build/Build.groovy
@@ -6,7 +6,9 @@ if (!CFG.dockerBuildImage) {
     error('Configuration error. Docker Image is expected to be set by specializing Module implementation.')
 }
 
-docker.image(CFG.dockerBuildImage).withRun(CFG.dockerWithRunParameters) {c -> 
+def dockerImage = docker.image(CFG.dockerBuildImage)
+dockerImage.pull()
+dockerImage.withRun(CFG.dockerWithRunParameters) {c -> 
     extendConfiguration([containerId: c.id])
     MPLModule('Build In Container')
 }

--- a/vars/MDSDToolsPipeline.groovy
+++ b/vars/MDSDToolsPipeline.groovy
@@ -3,7 +3,7 @@ def call(body) {
         agent_label = 'docker'
 
         buildWithMaven {
-            version = '3.6.0'
+            version = '3'
             jdkVersion = 11
             settingsId = 'fba2768e-c997-4043-b10b-b5ca461aff54'
             goal = 'clean verify'


### PR DESCRIPTION
This PR switches back to the latest Maven 3 image. Additionally, I configured the build to always check if there is a new version of an image.