### PR TITLE
Use forked maven image if available.

### DIFF
--- a/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/maven/modules/Container/SetupContainer.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/maven/modules/Container/SetupContainer.groovy
@@ -1,8 +1,18 @@
 def mavenVersion = CFG.mavenVersion ?: '3'
 def mavenJdkVersion = CFG.mavenJdkVersion ?: '11'
 
+// try to use a forked version of the maven image
+def mavenImageName = "maven:${mavenVersion}-jdk-${mavenJdkVersion}"
+def mavenImageFqn = "docker.mdsd.tools/${mavenImageName}"
+try{
+    def dockerImage = docker.image(mavenImageFqn)
+    dockerImage.pull()
+} catch (err){
+    mavenImageFqn = mavenImageName
+}
+
 extendConfiguration([
-    dockerBuildImage: "maven:${mavenVersion}-jdk-${mavenJdkVersion}",
+    dockerBuildImage: mavenImageFqn,
     dockerWithRunParameters: """\
     ${CFG.dockerWithRunParameters ?: ""} \
     -v ${CFG.slaveHome}/.m2:/.m2:ro \


### PR DESCRIPTION
We have some builds that - for whatever reason - require UI stuff to be loaded. Recent Maven images do not contain the GTK libraries required to do so, which causes tests to fail. I see no other way than forking these images and adding the stuff we require. To not break with existing syntax and features, I added a test for availability of our forked images. If a fork is available, it will be used.

The forks are producted by another project (see [Docker-Maven](https://github.com/MDSD-Tools/Docker-Maven)) and updated on a daily basis.

As a test project that failed before, I tried to build Simulizar of Palladio, which succeeded.

We have to switch back to the master branch in the Palladio build server before we can delete the corresponding branch.