### PR TITLE
Execute notification on master node.

### DIFF
--- a/vars/emailNotification.groovy
+++ b/vars/emailNotification.groovy
@@ -20,7 +20,7 @@ def notifyFailure(defaultRecipient) {
 }
 
 def notify(defaultRecipient, token, verb) {
-	node {
+	node ('master') {
 		wrap([$class: 'MaskPasswordsBuildWrapper', varMaskRegexes: [
 			[regex: '@[^\\s,]+']
 		]]) {


### PR DESCRIPTION
This PR fixes an issue when all build slots are occupied and a notification shall be sent.

Because we always execute build jobs on dedicated build slaves, there should be always room for executing the mail notification on the master. I activated the branch for a nightly build of Palladio and did not experience any issues.

Before deleting the branch, the Jenkins configuration has to be switched back to master.