### PR TITLE
PALLADIO-505 Do not use HTTP proxy anymore.

### DIFF
--- a/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/maven/modules/Container/SetupContainer.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/maven/modules/Container/SetupContainer.groovy
@@ -20,7 +20,6 @@ extendConfiguration([
     -v ${CFG.mavenSettingsFile}:/settings.xml:ro \
     -e MAVEN_CONFIG=/tmp/.m2 \
     -e MAVEN_OPTS=-Duser.home=/tmp \
-    -e USE_PROXY=true \
     """])
 
 MPLModule('Setup Container')

--- a/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/modules/Container/SetupContainer.groovy
+++ b/resources/tools/mdsd/devops/pipeline/stages/impl/dockerized/modules/Container/SetupContainer.groovy
@@ -2,7 +2,6 @@ extendConfiguration([dockerWithRunParameters: """\
         ${CFG.dockerWithRunParameters ?: ""} \
         -u ${CFG.slaveUid} \
         -v ${CFG.workspacePath}:/ws:ro \
-        --network proxy \
         -it \
         --entrypoint=/bin/cat \
         """])

--- a/vars/MDSDToolsPipeline.groovy
+++ b/vars/MDSDToolsPipeline.groovy
@@ -5,7 +5,7 @@ def call(body) {
         buildWithMaven {
             version = '3'
             jdkVersion = 11
-            settingsId = 'fba2768e-c997-4043-b10b-b5ca461aff54'
+            settingsId = 'fba2768e-c997-4043-b10b-b5ca461aff55'
             goal = 'clean verify'
         }
 


### PR DESCRIPTION
This PR disabled the usage of the HTTP proxy for resolving P2 artifacts. Instead, there is a new settings file configured in the build server that uses the tycho mirror feature. This simplifies our build infrastructure.

After merging the PR, we can remove the HTTP proxy from all slaves and archive the corresponding repository on Github.